### PR TITLE
reimplemented analysis status tracking

### DIFF
--- a/xbrowse_server/base/management/commands/migrate_analysis_status.py
+++ b/xbrowse_server/base/management/commands/migrate_analysis_status.py
@@ -4,15 +4,27 @@ from xbrowse_server.base.models import User, Project, Family, AnalysisStatus
 
 class Command(BaseCommand):
     """Command to copy Family.analysis_status into the new AnalysisStatus table. Family.analysis_status will later be deleted. """
+    def add_arguments(self, parser):
+        parser.add_argument("--reverse", action="store_true", help="migrate it back")
 
     def handle(self, *args, **options):
         counter = defaultdict(int)
-        for family in Family.objects.all():
-            counter['total'] += 1
-            if family.analysis_status:
-                analysis_status, created = AnalysisStatus.objects.get_or_create(family=family)
-                analysis_status.status=family.analysis_status
-                analysis_status.save()
+        if options["reverse"]:
+            for analysis_status in AnalysisStatus.objects.all():
+                counter['total'] += 1
+                family = analysis_status.family
+                family.analysis_status = analysis_status.status
+                family.analysis_status_date_saved = analysis_status.date_saved
+                family.analysis_status_saved_by = analysis_status.user
+                family.save()
                 counter['modified'] += 1
+        else:
+            for family in Family.objects.all():
+                counter['total'] += 1
+                #if family.analysis_status:
+                    #analysis_status, created = AnalysisStatus.objects.get_or_create(family=family)
+                    #analysis_status.status=family.analysis_status
+                    #analysis_status.save()
+                    #counter['modified'] += 1
 
         print("%s of %s (%s%%) families migrated" % (counter['modified'], counter['total'], 100.0*counter['modified']/float(counter['total'])))

--- a/xbrowse_server/base/views/family_views.py
+++ b/xbrowse_server/base/views/family_views.py
@@ -14,7 +14,7 @@ from xbrowse_server import server_utils
 from xbrowse.reference.utils import get_coding_regions_from_gene_structure
 from xbrowse.core import genomeloc
 from xbrowse_server.base.forms import EditFamilyForm, EditFamilyCauseForm
-from xbrowse_server.base.models import Project, Family, FamilySearchFlag, AnalysisStatus, ProjectGeneList, CausalVariant, ANALYSIS_STATUS_CHOICES
+from xbrowse_server.base.models import Project, Family, FamilySearchFlag, ProjectGeneList, CausalVariant, ANALYSIS_STATUS_CHOICES
 from xbrowse_server.decorators import log_request
 from xbrowse_server.base.lookups import get_saved_variants_for_family
 from xbrowse_server.api.utils import add_extra_info_to_variants_family
@@ -55,9 +55,9 @@ def family_home(request, project_id, family_id):
         if not (settings.PROJECTS_WITHOUT_PHENOTIPS is None or project_id in settings.PROJECTS_WITHOUT_PHENOTIPS):
             phenotips_supported=True
 
-        analysis_status_json = family.get_analysis_status().toJSON()
+        analysis_status_json = family.get_analysis_status_json()
         analysis_status_choices = dict(ANALYSIS_STATUS_CHOICES)
-        analysis_status_desc_and_icon = analysis_status_choices[family.get_analysis_status().status]
+        analysis_status_desc_and_icon = analysis_status_choices[family.analysis_status]
         return render(request, 'family/family_home.html', {
             'phenotips_supported':phenotips_supported,
             'project': project,
@@ -87,17 +87,14 @@ def edit_family(request, project_id, family_id):
             family.short_description = form.cleaned_data['short_description']
             family.about_family_content = form.cleaned_data['about_family_content']
             family.analysis_summary_content = form.cleaned_data['analysis_summary_content']
-            family.analysis_status = form.cleaned_data['analysis_status']
+
+            if family.analysis_status != form.cleaned_data['analysis_status']:
+                family.analysis_status = form.cleaned_data['analysis_status']
+                family.analysis_status_date_saved = datetime.datetime.now()
+                family.analysis_status_saved_by = request.user
             if 'pedigree_image' in request.FILES:
                 family.pedigree_image = request.FILES['pedigree_image']
             family.save()
-
-            analysis_status, created = AnalysisStatus.objects.get_or_create(family=family)
-            if created or analysis_status.status != form.cleaned_data['analysis_status']:
-                analysis_status.user = request.user
-                analysis_status.date_saved = datetime.datetime.now()
-                analysis_status.status = form.cleaned_data['analysis_status']
-                analysis_status.save()
 
             return redirect('family_home', project_id=project.project_id, family_id=family.family_id)
     else:

--- a/xbrowse_server/json_displays.py
+++ b/xbrowse_server/json_displays.py
@@ -33,7 +33,6 @@ def individual_list(_individual_list):
 def family_list(_family_list):
     family_d_list = []
     for family in _family_list:
-        analysis_status_obj = family.get_analysis_status()
         family_d_list.append({
             'url': reverse('family_home', args=(family.project.project_id, family.family_id)),
             'family_id': family.family_id,
@@ -43,7 +42,7 @@ def family_list(_family_list):
             'num_individuals': family.num_individuals(),
             'num_causal_variants': family.num_causal_variants(),
             'short_description': family.short_description,
-            'analysis_status' : analysis_status_obj.toJSON() if analysis_status_obj else None,
+            'analysis_status' : family.get_analysis_status_json(),
             'pedigree_image_url': family.pedigree_image.url if family.pedigree_image else None,            
             'phenotypes': [p.slug for p in family.get_phenotypes()],
         })

--- a/xbrowse_server/templates/family/family_home.html
+++ b/xbrowse_server/templates/family/family_home.html
@@ -118,8 +118,7 @@
                             {{ analysis_status_desc_and_icon.0 }}
                             {% if analysis_status_json.date_saved %}
                                 <br>
-                                (set {{ analysis_status_json.date_saved }} by
-                                {{ analysis_status_json.user }})
+                                (set by {{ analysis_status_json.user }} {{ analysis_status_json.date_saved }})
                             {% endif %}
                             {% if user_is_admin %}
                                 <br>


### PR DESCRIPTION
realized that for one-to-one relationships such as between Family and AnalsyisStatus, it's simpler to add fields to the Family model than to create a separate AnalysisStatus table where records need to be created/deleted in sync with Family records, so moving the analysis_status date_saved and saved_by fields into the Family model