### PR TITLE
making the public info/landing page of matchbox public again

### DIFF
--- a/xbrowse_server/matchmaker/views.py
+++ b/xbrowse_server/matchmaker/views.py
@@ -76,7 +76,6 @@ def matchbox_dashboard(request):
     return render(request, 'matchmaker/matchbox_dashboard.html', {})
 
 
-@staff_member_required(login_url=LOGIN_URL)
 @log_request('matchmaker_info_page')
 @csrf_exempt
 def matchbox_info_page(request):


### PR DESCRIPTION
This page is a public facing landing page (not auth required). It had been public before, but looks got private at some commit. Making public again