### PR TITLE
Fix gene search genotypes

### DIFF
--- a/xbrowse_server/base/views/project_views.py
+++ b/xbrowse_server/base/views/project_views.py
@@ -881,7 +881,10 @@ def gene_quicklook(request, project_id, gene_id):
                 rare_variant_dict[variant_id] = variant
                 project_variants.append(variant)
             else:
-                rare_variant_dict[variant_id].genotypes.update(variant.genotypes)
+                for indiv_id, genotype in variant.genotypes.items():
+                    existing_genotype = rare_variant_dict[variant_id].genotypes.get(indiv_id)
+                    if not existing_genotype or existing_genotype.num_alt < genotype.num_alt:
+                        rare_variant_dict[variant_id].genotypes[indiv_id] = genotype
 
         rare_variants.extend(project_variants)
 

--- a/xbrowse_server/base/views/project_views.py
+++ b/xbrowse_server/base/views/project_views.py
@@ -883,7 +883,7 @@ def gene_quicklook(request, project_id, gene_id):
             else:
                 for indiv_id, genotype in variant.genotypes.items():
                     existing_genotype = rare_variant_dict[variant_id].genotypes.get(indiv_id)
-                    if not existing_genotype or existing_genotype.num_alt < genotype.num_alt:
+                    if not existing_genotype or existing_genotype.num_alt == -1:
                         rare_variant_dict[variant_id].genotypes[indiv_id] = genotype
 
         rare_variants.extend(project_variants)


### PR DESCRIPTION
If a variant exists in multiple indices in gene search we were essentially just using the genotypes from the final index instead of all of them, because for individuals absent in an index we assign them a genotype with num_alt -1