### PR TITLE
Variant Searching does not display any results

### DIFF
--- a/xbrowse_server/templates/client_templates/basic_variant.html
+++ b/xbrowse_server/templates/client_templates/basic_variant.html
@@ -304,7 +304,7 @@
             <% if(worst_vep_annotation) { %>
                 <% if (worst_vep_annotation.lof == 'LC' || worst_vep_annotation.lof_flags == 'NAGNAG_SITE') {
                     var loftee_tooltip = '';
-                    if (worst_vep_annotation.lof_filter != '') {
+                    if (worst_vep_annotation.lof_filter != undefined && worst_vep_annotation.lof_filter != '') {
                         var lof_filters = _.uniq(worst_vep_annotation.lof_filter.split("&")).map(
                             function(lof_filter) {
                                 if(lof_filter == 'END_TRUNC') return 'LOFTEE: End Truncation<br>This variant falls in the last 5% of the transcript.';


### PR DESCRIPTION
This PR fixes problem with Variant Search feature.

Steps to reproduce:
 * Go to any project
 * Select sample with loaded dataset
 * Go to Variant Search
 * Select search method: "All Variants" and any severity, click "Search".

Expected behaviour:
List of variants is displayed.

Observed behaviour:
Throbber is displayed, no variants appear, error message is logged to JavaScript console:
```
VM1419:413 Uncaught TypeError: Cannot read property 'split' of undefined
    at r.eval (eval at w.template (underscore-min.js:1), <anonymous>:413:82)
    at r.c [as template] (underscore-min.js:1)
    at render (basic_variant.js:41)
    at basic_variants_table.js:44
    at Array.forEach (<anonymous>)
    at Function.w.each.w.forEach (underscore-min.js:1)
    at render (basic_variants_table.js:30)
    at render (mendelian_variant_search.js:387)
    at r.update_sort_order (mendelian_variant_search.js:349)
    at r.initialize (mendelian_variant_search.js:197)
```

