### PR TITLE
Migration "reference_data.0013_auto_20190404_1953" fails

### DIFF
--- a/reference_data/migrations/0013_auto_20190404_1953.py
+++ b/reference_data/migrations/0013_auto_20190404_1953.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='geneexpression',
             name='expression_values',
-            field=django.contrib.postgres.fields.ArrayField(base_field=models.FloatField(), size=None),
+            field=django.contrib.postgres.fields.ArrayField(base_field=models.FloatField(), size=None, default=list(), null=True),
         ),
         migrations.AlterField(
             model_name='geneexpression',


### PR DESCRIPTION
Steps to reproduce:
 * Create PostgreSQL database
 * Restore from https://storage.googleapis.com/seqr-reference-data/gene_reference_data_backup.gz
 * Apply migrations: "python manage.py migrate"

Observed behavior:
Migration reference_data.0013_auto_20190404_1953 fails with error:
```
Migrations for 'reference_data':
  reference_data/migrations/0015_auto_20190411_1329.py
    - Alter field expression_values on geneexpression
Operations to perform:
  Apply all migrations: admin, auth, base, breakpoint_search, contenttypes, gene_lists, guardian, reference_data, seqr, sessions
Running migrations:
  Applying base.0055_auto_20181106_1855... OK
  Applying base.0056_auto_20190410_1453... OK
  Applying reference_data.0010_auto_20190319_1518... OK
  Applying reference_data.0011_primateai... OK
  Applying reference_data.0012_auto_20190321_1656... OK
  Applying reference_data.0013_auto_20190404_1953...Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 204, in handle
    fake_initial=fake_initial,
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 115, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 145, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 244, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/migration.py", line 129, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/usr/local/lib/python2.7/site-packages/django/db/migrations/operations/fields.py", line 88, in database_forwards
    field,
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 445, in add_field
    self.execute(sql, params)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 136, in execute
    cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/usr/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: column "expression_values" contains null values
```


