### PR TITLE
increase size of pedigree image in inheritance search

### DIFF
--- a/ui/shared/components/panel/view-pedigree-image/PedigreeImagePanel.jsx
+++ b/ui/shared/components/panel/view-pedigree-image/PedigreeImagePanel.jsx
@@ -6,8 +6,8 @@ import styled from 'styled-components'
 import Modal from '../../modal/Modal'
 
 const PedigreeImage = styled.img.attrs({ alt: 'pedigree' })`
-  max-height: ${props => (props.compact ? '35px' : '100px')};
-  max-width: 150px;
+  max-height: ${props => (props.compact ? '35px' : '150px')};
+  max-width: 225px;
   vertical-align: top;
   cursor: ${props => (props.disablePedigreeZoom ? 'auto' : 'zoom-in')};
 `


### PR DESCRIPTION
Increase the size of the pedigree image in inheritance search to display larger labels in the images.