### PR TITLE
Added unit test for check_bam_cram_paths command.

### DIFF
--- a/seqr/management/commands/check_bam_cram_paths.py
+++ b/seqr/management/commands/check_bam_cram_paths.py
@@ -21,8 +21,8 @@ class Command(BaseCommand):
             except Exception as e:
                 individual_id = sample.individual.individual_id
                 failed.append(individual_id)
-                print('Error at {} (Individual: {}): {} '.format(sample.file_path, individual_id, e.message))
+                self.stdout.write('Error at {} (Individual: {}): {} '.format(sample.file_path, individual_id, e.message))
 
-        print('---- DONE ----')
-        print('Checked {} samples'.format(len(samples)))
-        print('{} failed samples: {}'.format(len(failed), ', '.join(failed)))
+        self.stdout.write('---- DONE ----')
+        self.stdout.write('Checked {} samples'.format(len(samples)))
+        self.stdout.write('{} failed samples: {}'.format(len(failed), ', '.join(failed)))

--- a/seqr/management/commands/check_bam_cram_paths_tests.py
+++ b/seqr/management/commands/check_bam_cram_paths_tests.py
@@ -1,0 +1,27 @@
+import mock
+
+from io import BytesIO
+from django.core.management import call_command
+from django.test import TestCase
+EXPECTED_EXCEPTION_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n'
+EXPECTED_NORMAL_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n'
+
+
+class AddProjectTagTest(TestCase):
+    fixtures = ['users', '1kg_project']
+
+    @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')
+    def test_normal_command(self, mock_validate_path):
+        mock_validate_path.return_value = ""
+        out = BytesIO()
+        call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
+
+        self.assertEqual(EXPECTED_NORMAL_MSG, out.getvalue())
+
+    @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')
+    def test_exception_command(self, mock_validate_path):
+        mock_validate_path.side_effect = Exception('Error accessing "/readviz/NA19675.cram"')
+        out = BytesIO()
+        call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
+
+        self.assertEqual(EXPECTED_EXCEPTION_MSG, out.getvalue())

--- a/seqr/management/commands/check_bam_cram_paths_tests.py
+++ b/seqr/management/commands/check_bam_cram_paths_tests.py
@@ -9,19 +9,19 @@ class CheckBamCramPathsTest(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')
-    def test_normal_command(self, mock_validate_path):
-        mock_validate_path.return_value = ""
+    def test_command(self, mock_validate_path):
         out = BytesIO()
         call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
 
-        self.assertEqual('Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n',
+        self.assertEqual('---- DONE ----\nChecked 1 samples\n0 failed samples: \n',
                          out.getvalue())
+        mock_validate_path.assert_called_with("/readviz/NA19675.cram")
 
-    @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')
-    def test_exception_command(self, mock_validate_path):
+        # Test exception
         mock_validate_path.side_effect = Exception('Error accessing "/readviz/NA19675.cram"')
         out = BytesIO()
         call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
 
         self.assertEqual('Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n',
                          out.getvalue())
+        mock_validate_path.assert_called_with("/readviz/NA19675.cram")

--- a/seqr/management/commands/check_bam_cram_paths_tests.py
+++ b/seqr/management/commands/check_bam_cram_paths_tests.py
@@ -3,8 +3,6 @@ import mock
 from io import BytesIO
 from django.core.management import call_command
 from django.test import TestCase
-EXPECTED_EXCEPTION_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n'
-EXPECTED_NORMAL_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n'
 
 
 class CheckBamCramPathsTest(TestCase):
@@ -16,7 +14,8 @@ class CheckBamCramPathsTest(TestCase):
         out = BytesIO()
         call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
 
-        self.assertEqual(EXPECTED_NORMAL_MSG, out.getvalue())
+        self.assertEqual('Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n',
+                         out.getvalue())
 
     @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')
     def test_exception_command(self, mock_validate_path):
@@ -24,4 +23,5 @@ class CheckBamCramPathsTest(TestCase):
         out = BytesIO()
         call_command('check_bam_cram_paths', u'1kg project n\u00e5me with uni\u00e7\u00f8de', stdout=out)
 
-        self.assertEqual(EXPECTED_EXCEPTION_MSG, out.getvalue())
+        self.assertEqual('Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n',
+                         out.getvalue())

--- a/seqr/management/commands/check_bam_cram_paths_tests.py
+++ b/seqr/management/commands/check_bam_cram_paths_tests.py
@@ -7,7 +7,7 @@ EXPECTED_EXCEPTION_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1)
 EXPECTED_NORMAL_MSG = 'Error at /readviz/NA19675.cram (Individual: NA19675_1): Error accessing "/readviz/NA19675.cram" \n---- DONE ----\nChecked 1 samples\n1 failed samples: NA19675_1\n'
 
 
-class AddProjectTagTest(TestCase):
+class CheckBamCramPathsTest(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch('seqr.views.utils.dataset_utils.validate_alignment_dataset_path')


### PR DESCRIPTION
Two tests have been added. One is normal test while another is for exception test.
A change: BytesIO is used instead of StringIO because stdout is written with a str rather than a unicode (if a unicode is provided then it is casted to str). 
The check_bam_cram_paths implementation must replace print() with self.stdout.write() according to https://docs.djangoproject.com/en/3.0/howto/custom-management-commands/