### PR TITLE
Seqr management command lift_project_to_hg38 unit test

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1150,7 +1150,7 @@
                 {"transcriptId": "ENST00000421966", "lofFilter": "", "biotype": "nonsense_mediated_decay", "geneSymbol": "MFSD9", "majorConsequence": "downstream_gene_variant", "canonical": "", "hgvsp": "", "lof": "", "lofFlags": "", "codons": "", "hgvsc": "", "transcriptRank": 100, "geneId": "ENSG00000135953", "aminoAcids": "", "cdnaPosition": null}, {"transcriptId": "ENST00000428085", "lofFilter": "", "biotype": "nonsense_mediated_decay", "geneSymbol": "MFSD9", "majorConsequence": "inframe_deletion", "canonical": "", "hgvsp": "ENSP00000413641.1:p.Leu48del", "lof": "", "lofFlags": "", "codons": "ctTCTc/ctc", "hgvsc": "ENST00000428085.1:c.141_143delTCT", "transcriptRank": 100, "geneId": "ENSG00000135953", "aminoAcids": "LL/L", "cdnaPosition": "141-143"},
                 {"transcriptId": "ENST00000437075", "lofFilter": "", "biotype": "nonsense_mediated_decay", "geneSymbol": "MFSD9", "majorConsequence": "3_prime_UTR_variant", "canonical": "", "hgvsp": "", "lof": "", "lofFlags": "", "codons": "", "hgvsc": "ENST00000437075.2:c.*176_*178delTCT", "transcriptRank": 100, "geneId": "ENSG00000135953", "aminoAcids": "", "cdnaPosition": "541-543"},
                 {"transcriptId": "ENST00000438943", "lofFilter": "", "biotype": "nonsense_mediated_decay", "geneSymbol": "MFSD9", "majorConsequence": "3_prime_UTR_variant", "canonical": "", "hgvsp": "", "lof": "", "lofFlags": "", "codons": "", "hgvsc": "ENST00000438943.1:c.*211_*213delTCT", "transcriptRank": 100, "geneId": "ENSG00000135953", "aminoAcids": "", "cdnaPosition": "558-560"}]},
-            "chrom": "2",
+            "chrom": "21",
             "genotypes": {"I000003_na19679": {"sampleId": "NA19679", "ab": 0.0, "ad": "45,0", "gq": 99.0, "dp": "45", "pl": "0,135,1525", "cnvs": {"size": null, "snps": null, "cn": null, "LRR_sd": null, "array": null, "caller": null, "type": null, "freq": null, "LRR_median": null}, "numAlt": 0}, "I000002_na19678": {"sampleId": "NA19678", "ab": 0.0, "ad": "42,0", "gq": 99.0, "dp": "43", "pl": "0,126,1479", "cnvs": {"size": null, "snps": null, "cn": null, "LRR_sd": null, "array": null, "caller": null, "type": null, "freq": null, "LRR_median": null}, "numAlt": 0}, "I000001_na19675": {"sampleId": "NA19675_1", "ab": 0.7021276595744681, "ad": "14,33", "gq": 46.0, "dp": "50", "pl": "46,0,686", "cnvs": {"size": null, "snps": null, "cn": null, "LRR_sd": null, "array": null, "caller": null, "type": null, "freq": null, "LRR_median": null}, "numAlt": 1}}
         },
         "family": 1
@@ -1318,7 +1318,7 @@
             "mainTranscriptId": "ENST00000505820",
             "populations": {"callset": {"ac": null, "an": null, "af": null}, "g1k": {"ac": null, "an": null, "af": 0.0}, "gnomad_genomes": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 0.0}, "gnomad_exomes": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 8.142526788913136e-06}, "exac": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 0.0}, "topmed": {"ac": null, "an": null, "af": null}},
             "genomeVersion": "37",
-            "pos": 46859832,
+            "pos": 1560662,
             "predictions": {"eigen": null, "revel": null, "sift": "damaging", "cadd": "31", "metasvm": "D", "mpc": null, "splice_ai": null, "phastcons_100_vert": null, "mut_taster": "disease_causing", "fathmm": "tolerated", "polyphen": "probably_damaging", "dann": null, "primate_ai": null, "gerp_rs": null},
             "hgmd": {"accession": null, "class": null},
             "rsid": null,

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1169,7 +1169,130 @@
         "ref": "TC",
         "alt": "T",
         "variant_id": "12-48367227-TC-T",
-        "saved_variant_json": {"clinvar": {"clinicalSignificance": "", "alleleId": null, "variationId": null, "goldStars": null}, "liftedOverGenomeVersion": "38", "familyGuids": ["F000001_1"], "liftedOverPos": "", "genotypeFilters": "pass", "mainTranscriptId": null, "populations": {"callset": {"ac": null, "an": null, "af": null}, "g1k": {"ac": null, "an": null, "af": 0.0}, "gnomad_genomes": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 0.00012925741614425127}, "gnomad_exomes": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 6.505916317651364e-05}, "exac": {"hemi": null, "ac": null, "an": null, "hom": null, "af": 0.0006726888333653661}, "topmed": {"ac": null, "an": null, "af": null}}, "genomeVersion": "37", "pos": 248367227, "predictions": {"eigen": null, "revel": null, "sift": null, "cadd": "27.2", "metasvm": "", "mpc": null, "splice_ai": null, "phastcons_100_vert": null, "mut_taster": null, "fathmm": null, "polyphen": null, "dann": null, "primate_ai": null, "gerp_rs": null}, "hgmd": {"accession": null, "class": null}, "rsid": null, "liftedOverChrom": "", "originalAltAlleles": ["T"], "transcripts": {}, "chrom": "1", "genotypes": {"I000003_na19679": {"sampleId": "NA19679", "ab": 0.0, "ad": "71,0", "gq": 99.0, "dp": "71", "pl": "0,213,1918", "cnvs": {"size": null, "snps": null, "cn": null, "LRR_sd": null, "array": null, "caller": null, "type": null, "freq": null, "LRR_median": null}, "numAlt": 0}, "I000002_na19678": {"sampleId": "NA19678", "ab": 0.0, "ad": "77,0", "gq": 99.0, "dp": "77", "pl": "0,232,3036", "cnvs": {"size": null, "snps": null, "cn": null, "LRR_sd": null, "array": null, "caller": null, "type": null, "freq": null, "LRR_median": null}, "numAlt": 0}}},
+        "saved_variant_json": {
+            "clinvar": {
+                "clinicalSignificance": "",
+                "alleleId": null,
+                "variationId": null,
+                "goldStars": null
+            },
+            "liftedOverGenomeVersion": "38",
+            "familyGuids": [
+                "F000001_1"
+            ],
+            "liftedOverPos": "",
+            "genotypeFilters": "pass",
+            "mainTranscriptId": null,
+            "populations": {
+                "callset": {
+                    "ac": null,
+                    "an": null,
+                    "af": null
+                },
+                "g1k": {
+                    "ac": null,
+                    "an": null,
+                    "af": 0.0
+                },
+                "gnomad_genomes": {
+                    "hemi": null,
+                    "ac": null,
+                    "an": null,
+                    "hom": null,
+                    "af": 0.00012925741614425127
+                },
+                "gnomad_exomes": {
+                    "hemi": null,
+                    "ac": null,
+                    "an": null,
+                    "hom": null,
+                    "af": 6.505916317651364e-05
+                },
+                "exac": {
+                    "hemi": null,
+                    "ac": null,
+                    "an": null,
+                    "hom": null,
+                    "af": 0.0006726888333653661
+                },
+                "topmed": {
+                    "ac": null,
+                    "an": null,
+                    "af": null
+                }
+            },
+            "genomeVersion": "37",
+            "pos": 248367227,
+            "predictions": {
+                "eigen": null,
+                "revel": null,
+                "sift": null,
+                "cadd": "27.2",
+                "metasvm": "",
+                "mpc": null,
+                "splice_ai": null,
+                "phastcons_100_vert": null,
+                "mut_taster": null,
+                "fathmm": null,
+                "polyphen": null,
+                "dann": null,
+                "primate_ai": null,
+                "gerp_rs": null
+            },
+            "hgmd": {
+                "accession": null,
+                "class": null
+            },
+            "rsid": null,
+            "liftedOverChrom": "",
+            "originalAltAlleles": [
+                "T"
+            ],
+            "transcripts": {},
+            "chrom": "1",
+            "genotypes": {
+                "I000003_na19679": {
+                    "sampleId": "NA19679",
+                    "ab": 0.0,
+                    "ad": "71,0",
+                    "gq": 99.0,
+                    "dp": "71",
+                    "pl": "0,213,1918",
+                    "cnvs": {
+                        "size": null,
+                        "snps": null,
+                        "cn": null,
+                        "LRR_sd": null,
+                        "array": null,
+                        "caller": null,
+                        "type": null,
+                        "freq": null,
+                        "LRR_median": null
+                    },
+                    "numAlt": 0
+                },
+                "I000002_na19678": {
+                    "sampleId": "NA19678",
+                    "ab": 0.0,
+                    "ad": "77,0",
+                    "gq": 99.0,
+                    "dp": "77",
+                    "pl": "0,232,3036",
+                    "cnvs": {
+                        "size": null,
+                        "snps": null,
+                        "cn": null,
+                        "LRR_sd": null,
+                        "array": null,
+                        "caller": null,
+                        "type": null,
+                        "freq": null,
+                        "LRR_median": null
+                    },
+                    "numAlt": 0
+                }
+            }
+        },
         "family": 2
     }
 },

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -39,7 +39,6 @@ class Command(BaseCommand):
         sample_ids, index_metadata = get_elasticsearch_index_samples(elasticsearch_index)
         validate_index_metadata(index_metadata, project, elasticsearch_index, genome_version=GENOME_VERSION_GRCh38)
         sample_type = index_metadata['sampleType']
-        dataset_path = index_metadata['sourceFilePath']
 
         matched_sample_id_to_sample_record = match_sample_ids_to_sample_records(
             project=project,

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         elasticsearch_index = options['es_index']
 
         project = Project.objects.get(Q(name=project_arg) | Q(guid=project_arg))
-        logger.info('Updating project genome version for {}'.format(project.name))
+        logger.info(u'Updating project genome version for {}'.format(project.name))
 
         # Validate the provided index
         logger.info('Validating es index {}'.format(elasticsearch_index))
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                 ))
 
         # Lift-over saved variants
-        _update_variant_samples(matched_sample_id_to_sample_record, elasticsearch_index, dataset_path)
+        _update_variant_samples(matched_sample_id_to_sample_record, elasticsearch_index)
         saved_variants = get_json_for_saved_variants(saved_variant_models_by_guid.values(), add_details=True)
         saved_variants_to_lift = [v for v in saved_variants if v['genomeVersion'] != GENOME_VERSION_GRCh38]
 

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -3,9 +3,9 @@ import mock
 import __builtin__
 from copy import deepcopy
 from django.core.management.base import CommandError
-from seqr.models import Family, Individual, SavedVariant
+from seqr.models import Family
 from pyliftover.liftover import LiftOver
-from seqr.views.utils.test_utils import VARIANTS
+from seqr.views.utils.test_utils import VARIANTS, SINGLE_VARIANT
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -24,23 +24,33 @@ SAMPLE_IDS = ["NA19679", "NA19675_1", "NA19678", "HG00731", "HG00732", "HG00733"
 
 liftover_to_38 = LiftOver('hg19', 'hg38')
 
+LIFT_MAP = {
+    21003343353L: [('chr21', 3343400)],
+    1248367227L: [('chr1', 248203925)],
+    1001562437L: [('chr1',   1627057)],
+    1001560662L: [('chr1',  46394160)],
+}
 
-# To create a none return value for the variant at pos 1562437
+
 def mock_convert_coordinate(chrom, pos):
-    if pos == 1562437:
-        return
-    return liftover_to_38.convert_coordinate(chrom, pos)
+    pos = int(chrom.replace('chr', ''))*int(1e9) + pos
+    if pos in LIFT_MAP.keys():
+        return(LIFT_MAP[pos])
+
 
 @mock.patch('seqr.management.commands.lift_project_to_hg38.logger')
+@mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
 class LiftProjectToHg38Test(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch.object(__builtin__, 'raw_input')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
-    def test_command(self, mock_get_es_variants, mock_get_es_samples, mock_input, mock_logger):
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
+    def test_command(self, mock_liftover, mock_get_es_variants, mock_input, mock_get_es_samples, mock_logger):
         mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
         mock_get_es_variants.return_value = VARIANTS
+        mock_liftover_to_38 = mock_liftover.return_value
+        mock_liftover_to_38.convert_coordinate.side_effect = mock_convert_coordinate
         mock_input.return_value = 'y'
         call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                      '--es-index={}'.format(ELASTICSEARCH_INDEX))
@@ -52,16 +62,28 @@ class LiftProjectToHg38Test(TestCase):
             mock.call('Successfully lifted over 3 variants'),
             mock.call('Successfully updated 3 variants'),
             mock.call('---Done---'),
-            mock.call('Succesfully lifted over 3 variants. Skipped 4 failed variants. Family data not updated for 0 variants')
+            mock.call('Succesfully lifted over 3 variants. Skipped 3 failed variants. Family data not updated for 0 variants')
         ]
         mock_logger.info.assert_has_calls(calls)
 
         mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
-        mock_get_es_variants.assert_called_with(mock.ANY, [(1001627057, u'G', u'C'), (1046394160, u'G', u'A'), (1248203925, u'TC', u'T'), (2003339582, u'GAGA', u'G')])
+
+        calls = [
+            mock.call('chr21', 3343353),
+            mock.call('chr1', 1562437),
+            mock.call('chr1', 248367227),
+            mock.call('chr1', 1560662),
+        ]
+        mock_liftover_to_38.convert_coordinate.assert_has_calls(calls, any_order = True)
+        
+        families = {family for family in Family.objects.filter(pk__in = [1, 2])}
+        self.assertSetEqual(families, mock_get_es_variants.call_args.args[0])
+        self.assertSetEqual(set([(1001627057, u'G', u'C'), (21003343400, u'GAGA', u'G'), (1248203925, u'TC', u'T'),
+                                 (1046394160, u'G', u'A')]), set(mock_get_es_variants.call_args.args[1]))
 
         # Test discontinue on lifted variants
         mock_logger.reset_mock()
-        mock_input.return_value = 'n'
+        mock_input.side_effect = 'n'
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
@@ -74,7 +96,6 @@ class LiftProjectToHg38Test(TestCase):
         ]
         mock_logger.info.assert_has_calls(calls)
 
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
     def test_command_error_unmatched_sample(self, mock_get_es_samples, mock_logger):
         mock_get_es_samples.return_value = ['ID_NOT_EXIST'], INDEX_METADATA
 
@@ -92,20 +113,15 @@ class LiftProjectToHg38Test(TestCase):
 
         mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
 
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.Individual')
-    def test_command_error_missing_indvididuals(self, mock_Individual, mock_get_es_samples, mock_logger):
-        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
+    def test_command_error_missing_indvididuals(self, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = ['NA19675_1'], INDEX_METADATA
 
-        mock_ind = mock_Individual.objects.filter.return_value
-        mock_exclude_ind = mock_ind.exclude.return_value
-        family = Family.objects.get(pk=1)
-        mock_exclude_ind.select_related.return_value = [Individual.objects.create(family = family, individual_id = "NO_MATCHED_SAMPLE_IND_ID")]
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 
-        self.assertEqual(ce.exception.message, 'The following families are included in the callset but are missing some family members: 1 (NO_MATCHED_SAMPLE_IND_ID).')
+        self.assertEqual(ce.exception.message,
+            'The following families are included in the callset but are missing some family members: 1 (NA19678).')
 
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
@@ -115,19 +131,15 @@ class LiftProjectToHg38Test(TestCase):
 
         mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
 
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.SavedVariant')
-    def test_command_error_missing_families(self, mock_SavedVariant, mock_get_es_samples, mock_logger):
-        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
-
-        saved_variants = SavedVariant.objects.filter(pk__in=[1,2,6])
-        mock_SavedVariant.objects.filter.return_value = saved_variants
+    def test_command_error_missing_families(self, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = ['HG00731', 'HG00732', 'HG00733'], INDEX_METADATA
 
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 
-        self.assertEqual(ce.exception.message, 'The following families have saved variants but are missing from the callset: 11.')
+        self.assertEqual(ce.exception.message,
+            'The following families have saved variants but are missing from the callset: 1.')
 
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
@@ -138,60 +150,55 @@ class LiftProjectToHg38Test(TestCase):
         mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
 
     @mock.patch.object(__builtin__, 'raw_input')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.get_single_es_variant')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
     def test_command_other_exceptions(self, mock_liftover, mock_single_es_variants,
-            mock_get_es_variants, mock_get_es_samples, mock_input, mock_logger):
-        mock_get_es_samples.return_value = VARIANTS, INDEX_METADATA
+            mock_get_es_variants, mock_input, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
 
         # Test discontinue on a failed lift
         mock_liftover_to_38 = mock_liftover.return_value
-        mock_liftover_to_38.convert_coordinate.side_effect = mock_convert_coordinate
-        mock_input.side_effect = ['y', 'n']
+        mock_liftover_to_38.convert_coordinate.return_value = None
+        mock_input.return_value = 'n'
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 
-        self.assertEqual(ce.exception.message, 'Error: unable to lift over 1 variants')
+        self.assertEqual(ce.exception.message, 'Error: unable to lift over 4 variants')
 
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index'),
-            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)')
+            mock.call('Lifting over 4 variants (skipping 0 that are already lifted)')
         ]
         mock_logger.info.assert_has_calls(calls)
-
-        calls = [
-            mock.call("chr1", 1562437),
-            mock.call("chr1", 248367227),
-            mock.call("chr1", 46859832),
-        ]
-        mock_liftover_to_38.convert_coordinate.assert_has_calls(calls, any_order = True)
 
         # Test discontinue on failure of finding a variant in the index
-        mock_get_es_variants.return_value = VARIANTS[:1]
+        mock_get_es_variants.return_value = VARIANTS
+        mock_liftover_to_38.convert_coordinate.side_effect = mock_convert_coordinate
         mock_logger.reset_mock()
-        mock_input.side_effect = ['y', 'y', 'n']
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 
-        self.assertEqual(ce.exception.message, 'Error: unable to find 1 lifted-over variants')
+        self.assertEqual(ce.exception.message, 'Error: unable to find 3 lifted-over variants')
 
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index'),
-            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)')
+            mock.call('Lifting over 4 variants (skipping 0 that are already lifted)')
         ]
         mock_logger.info.assert_has_calls(calls)
 
-        mock_get_es_variants.assert_called_with(mock.ANY, [(1046394160, u'G', u'A'), (1248203925, u'TC', u'T')])
+        mock_get_es_variants.assert_called_with(mock.ANY, [(1001627057, u'G', u'C'), (21003343400, u'GAGA', u'G'), (1248203925, u'TC', u'T'), (1046394160, u'G', u'A')])
 
         # Test discontinue on missing family data while updating the saved variants
+        variants = deepcopy(VARIANTS)
+        variants.append(SINGLE_VARIANT)
+        mock_get_es_variants.return_value = variants
         mock_logger.reset_mock()
-        mock_input.side_effect = ['y', 'y', 'y', 'n']
+        mock_input.side_effect = ['y', 'n']
         with self.assertRaises(CommandError) as ce:
             call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
@@ -201,14 +208,15 @@ class LiftProjectToHg38Test(TestCase):
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index'),
-            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)'),
-            mock.call('Successfully lifted over 1 variants')
+            mock.call('Lifting over 4 variants (skipping 0 that are already lifted)'),
+            mock.call('Successfully lifted over 4 variants')
         ]
         mock_logger.info.assert_has_calls(calls)
 
-        mock_single_es_variants.return_value = VARIANTS[1]
+        mock_single_es_variants.return_value = SINGLE_VARIANT
         mock_logger.reset_mock()
-        mock_input.side_effect = ['y', 'y', 'y', 'y']
+        mock_input.reset_mock(side_effect = True)
+        mock_input.return_value = 'y'
         call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                      '--es-index={}'.format(ELASTICSEARCH_INDEX))
 
@@ -216,12 +224,12 @@ class LiftProjectToHg38Test(TestCase):
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index'),
             mock.call('Lifting over 3 variants (skipping 1 that are already lifted)'),
-            mock.call('Successfully lifted over 1 variants'),
-            mock.call('Successfully updated 1 variants'),
+            mock.call('Successfully lifted over 4 variants'),
+            mock.call('Successfully updated 4 variants'),
             mock.call('---Done---'),
-            mock.call('Succesfully lifted over 1 variants. Skipped 2 failed variants. Family data not updated for 1 variants')
+            mock.call('Succesfully lifted over 4 variants. Skipped 2 failed variants. Family data not updated for 1 variants')
         ]
         mock_logger.info.assert_has_calls(calls)
 
         families = [f for f in Family.objects.filter(pk=1)]
-        mock_single_es_variants.assert_called_with(families, '1-248367227-G-A', return_all_queried_families=True)
+        mock_single_es_variants.assert_called_with(families, '1-46394160-G-A', return_all_queried_families=True)

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -1,5 +1,6 @@
 #-*- coding: utf-8 -*-
 import mock
+import __builtin__
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -111,7 +112,7 @@ ES_VARIANTS = [
         'alt': 'T',
         'chrom': '1',
         'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000003_3'],
+        'familyGuids': ['F000002_2'],
         'genotypes': {
             'I000007_na20870': {
                 'ab': 1, 'ad': None, 'gq': 99, 'sampleId': 'NA20870', 'numAlt': 2, 'dp': 74, 'pl': None,
@@ -137,7 +138,7 @@ ES_VARIANTS = [
             'topmed': {'an': 125568, 'ac': 21, 'hom': 0, 'af': 0.00016724, 'hemi': 0, 'filter_af': None},
             'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
         },
-        'pos': 248367227,
+        'pos': 248203925,
         'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
                         'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
                         'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
@@ -147,18 +148,18 @@ ES_VARIANTS = [
             'ENSG00000135953': [TRANSCRIPT_3],
             'ENSG00000228198': [TRANSCRIPT_2],
         },
-        'variantId': '1-248367227-TC-T',
-        'xpos': 1248367227,
+        'variantId': '1-248203925-TC-T',
+        'xpos': 1248203925,
         'end': None,
         'svType': None,
         'numExon': None,
-        '_sort': [1248367227],
+        '_sort': [1248203925],
     },
     {
         'alt': 'G',
         'chrom': '2',
         'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000002_2', 'F000003_3'],
+        'familyGuids': ['F000001_1', 'F000003_3'],
         'genotypes': {
             'I000004_hg00731': {
                 'ab': 0, 'ad': None, 'gq': 99, 'sampleId': 'HG00731', 'numAlt': 0, 'dp': 67, 'pl': None,
@@ -195,7 +196,7 @@ ES_VARIANTS = [
             'topmed': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
             'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
         },
-        'pos': 103343353,
+        'pos': 3339582,
         'predictions': {
             'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
             'dann': None, 'sift': None, 'cadd': 17.26, 'metasvm': None, 'primate_ai': None, 'gerp_rs': None,
@@ -207,12 +208,122 @@ ES_VARIANTS = [
             'ENSG00000135953': [TRANSCRIPT_1],
             'ENSG00000228198': [TRANSCRIPT_2],
         },
-        'variantId': '2-103343353-GAGA-G',
-        'xpos': 2103343353,
+        'variantId': '2-003339582-GAGA-G',
+        'xpos': 2003339582,
         'end': None,
         'svType': None,
         'numExon': None,
-        '_sort': [2103343353],
+        '_sort': [2003339582],
+    },
+]
+
+SINGLE_ES_VARIANTS = [
+    {
+        'alt': 'C',
+        'chrom': '1',
+        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
+        'familyGuids': ['F000002_2', 'F000003_3'],
+        'genotypes': {
+            'I000007_na20870': {
+                'ab': 1, 'ad': None, 'gq': 99, 'sampleId': 'NA20870', 'numAlt': 2, 'dp': 74, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            }
+        },
+        'genomeVersion': '37',
+        'genotypeFilters': '',
+        'hgmd': {'accession': None, 'class': None},
+        'liftedOverChrom': None,
+        'liftedOverGenomeVersion': None,
+        'liftedOverPos': None,
+        'mainTranscriptId': TRANSCRIPT_3['transcriptId'],
+        'originalAltAlleles': ['T'],
+        'populations': {
+            'callset': {'an': 32, 'ac': 2, 'hom': None, 'af': 0.063, 'hemi': None, 'filter_af': None},
+            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'gnomad_genomes': {'an': 30946, 'ac': 4, 'hom': 0, 'af': 0.00012925741614425127, 'hemi': 0,
+                               'filter_af': 0.000437},
+            'exac': {'an': 121308, 'ac': 8, 'hom': 0, 'af': 0.00006589, 'hemi': 0, 'filter_af': 0.0006726888333653661},
+            'gnomad_exomes': {'an': 245930, 'ac': 16, 'hom': 0, 'af': 0.00006505916317651364, 'hemi': 0,
+                              'filter_af': 0.0009151523074911753},
+            'topmed': {'an': 125568, 'ac': 21, 'hom': 0, 'af': 0.00016724, 'hemi': 0, 'filter_af': None},
+            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
+        },
+        'pos': 248203925,
+        'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
+                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
+                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
+        'ref': 'TC',
+        'rsid': None,
+        'transcripts': {
+            'ENSG00000135953': [TRANSCRIPT_3],
+            'ENSG00000228198': [TRANSCRIPT_2],
+        },
+        'variantId': '1-248203925-TC-T',
+        'xpos': 1248203925,
+        'end': None,
+        'svType': None,
+        'numExon': None,
+        '_sort': [1248203925],
+    },
+    {
+        'alt': 'G',
+        'chrom': '2',
+        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
+        'familyGuids': ['F000001_1', 'F000002_2', 'F000003_3'],
+        'genotypes': {
+            'I000004_hg00731': {
+                'ab': 0, 'ad': None, 'gq': 99, 'sampleId': 'HG00731', 'numAlt': 0, 'dp': 67, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000005_hg00732': {
+                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00732', 'numAlt': 2, 'dp': 42, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000006_hg00733': {
+                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00733', 'numAlt': 1, 'dp': 42, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000007_na20870': {
+                'ab': 0.70212764, 'ad': None, 'gq': 46, 'sampleId': 'NA20870', 'numAlt': 1, 'dp': 50, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            }
+        },
+        'genotypeFilters': '',
+        'genomeVersion': '37',
+        'hgmd': {'accession': None, 'class': None},
+        'liftedOverGenomeVersion': None,
+        'liftedOverChrom': None,
+        'liftedOverPos': None,
+        'mainTranscriptId': TRANSCRIPT_1['transcriptId'],
+        'originalAltAlleles': ['G'],
+        'populations': {
+            'callset': {'an': 32, 'ac': 1, 'hom': None, 'af': 0.031, 'hemi': None, 'filter_af': None},
+            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'gnomad_genomes': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'exac': {'an': 121336, 'ac': 6, 'hom': 0, 'af': 0.00004942, 'hemi': 0, 'filter_af': 0.000242306760358614},
+            'gnomad_exomes': {'an': 245714, 'ac': 6, 'hom': 0, 'af': 0.000024418633044922146, 'hemi': 0,
+                              'filter_af': 0.00016269686320447742},
+            'topmed': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
+        },
+        'pos': 3339582,
+        'predictions': {
+            'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
+            'dann': None, 'sift': None, 'cadd': 17.26, 'metasvm': None, 'primate_ai': None, 'gerp_rs': None,
+            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
+        },
+        'ref': 'GAGA',
+        'rsid': None,
+        'transcripts': {
+            'ENSG00000135953': [TRANSCRIPT_1],
+            'ENSG00000228198': [TRANSCRIPT_2],
+        },
+        'variantId': '2-003339582-GAGA-G',
+        'xpos': 2003339582,
+        'end': None,
+        'svType': None,
+        'numExon': None,
+        '_sort': [2003339582],
     },
 ]
 
@@ -220,18 +331,27 @@ ES_VARIANTS = [
 class LiftProjectToHg38Test(TestCase):
     fixtures = ['users', '1kg_project']
 
+    @mock.patch.object(__builtin__, 'raw_input')
     @mock.patch('logging.getLogger')
     @mock.patch('seqr.views.utils.dataset_utils.get_elasticsearch_index_samples')
     @mock.patch('seqr.utils.elasticsearch.utils.get_es_variants_for_variant_tuples')
-    def test_command(self, mock_get_es_variants, mock_get_es_samples, mock_getLogger):
-        logger = mock_getLogger.return_value
+    @mock.patch('seqr.utils.elasticsearch.utils.get_single_es_variant')
+    def test_command(self, mock_single_es_variants, mock_get_es_variants, mock_get_es_samples, mock_getLogger, mock_input):
+        mock_logger = mock_getLogger.return_value
         mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
         mock_get_es_variants.return_value = ES_VARIANTS
+        mock_single_es_variants.side_effect = SINGLE_ES_VARIANTS
+        mock_input.return_value = 'y'
         call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                      '--es-index={}'.format(ELASTICSEARCH_INDEX))
-        
+
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
-            mock.call('Validating es index test_index')
+            mock.call('Validating es index test_index'),
+            mock.call('Lifting over 4 variants (skipping 0 that are already lifted)'),
+            mock.call('Successfully lifted over 2 variants'),
+            mock.call('Successfully updated 2 variants'),
+            mock.call('---Done---'),
+            mock.call('Succesfully lifted over 2 variants. Skipped 2 failed variants. Family data not updated for 0 variants')
         ]
-        logger.info.assert_has_calls(calls)
+        mock_logger.info.assert_has_calls(calls)

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -1,6 +1,11 @@
 #-*- coding: utf-8 -*-
 import mock
 import __builtin__
+from copy import deepcopy
+from django.core.management.base import CommandError
+from seqr.models import Family, Individual, SavedVariant
+from pyliftover.liftover import LiftOver
+from seqr.views.utils.test_utils import VARIANTS
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -9,338 +14,33 @@ PROJECT_NAME = u'1kg project n\u00e5me with uni\u00e7\u00f8de'
 PROJECT_GUID = 'R0001_1kg'
 ELASTICSEARCH_INDEX = 'test_index'
 INDEX_METADATA = {
-                    "gencodeVersion": "25",
-                    "hail_version": "0.2.24",
-                    "genomeVersion": "38",
-                    "sampleType": "WES",
-                    "sourceFilePath": "test_index_alias_1_path.vcf.gz",
-                }
-SAMPLE_IDS = ["NA19679", "NA19675_1", "NA19678", "HG00731", "HG00732", "HG00732", "HG00733"]
-
-TRANSCRIPT_1 = {
-  'aminoAcids': 'LL/L',
-  'biotype': 'protein_coding',
-  'lof': None,
-  'lofFlags': None,
-  'majorConsequenceRank': 10,
-  'codons': 'ctTCTc/ctc',
-  'geneSymbol': 'MFSD9',
-  'domains': [
-    'Transmembrane_helices:TMhelix',
-    'PROSITE_profiles:PS50850',
-  ],
-  'canonical': 1,
-  'transcriptRank': 0,
-  'cdnaEnd': 421,
-  'lofFilter': None,
-  'hgvs': 'ENSP00000258436.5:p.Leu126del',
-  'hgvsc': 'ENST00000258436.5:c.375_377delTCT',
-  'cdnaStart': 419,
-  'transcriptId': 'ENST00000258436',
-  'proteinId': 'ENSP00000258436',
-  'category': 'missense',
-  'geneId': 'ENSG00000135953',
-  'hgvsp': 'ENSP00000258436.5:p.Leu126del',
-  'majorConsequence': 'inframe_deletion',
-  'consequenceTerms': [
-    'inframe_deletion'
-  ]
+    "gencodeVersion": "25",
+    "hail_version": "0.2.24",
+    "genomeVersion": "38",
+    "sampleType": "WES",
+    "sourceFilePath": "test_index_alias_1_path.vcf.gz",
 }
-TRANSCRIPT_2 = {
-  'aminoAcids': 'P/X',
-  'biotype': 'protein_coding',
-  'lof': None,
-  'lofFlags': None,
-  'majorConsequenceRank': 4,
-  'codons': 'Ccc/cc',
-  'geneSymbol': 'OR2M3',
-  'domains': [
-    'Transmembrane_helices:TMhelix',
-    'Prints_domain:PR00237',
-  ],
-  'canonical': 1,
-  'transcriptRank': 0,
-  'cdnaEnd': 897,
-  'lofFilter': None,
-  'hgvs': 'ENSP00000389625.1:p.Leu288SerfsTer10',
-  'hgvsc': 'ENST00000456743.1:c.862delC',
-  'cdnaStart': 897,
-  'transcriptId': 'ENST00000456743',
-  'proteinId': 'ENSP00000389625',
-  'category': 'lof',
-  'geneId': 'ENSG00000228198',
-  'hgvsp': 'ENSP00000389625.1:p.Leu288SerfsTer10',
-  'majorConsequence': 'frameshift_variant',
-  'consequenceTerms': [
-    'frameshift_variant'
-  ]
-}
-TRANSCRIPT_3 = {
-  'aminoAcids': 'LL/L',
-  'biotype': 'nonsense_mediated_decay',
-  'lof': None,
-  'lofFlags': None,
-  'majorConsequenceRank': 10,
-  'codons': 'ctTCTc/ctc',
-  'geneSymbol': 'MFSD9',
-  'domains': [
-    'Transmembrane_helices:TMhelix',
-    'Gene3D:1',
-  ],
-  'canonical': None,
-  'transcriptRank': 1,
-  'cdnaEnd': 143,
-  'lofFilter': None,
-  'hgvs': 'ENSP00000413641.1:p.Leu48del',
-  'hgvsc': 'ENST00000428085.1:c.141_143delTCT',
-  'cdnaStart': 141,
-  'transcriptId': 'ENST00000428085',
-  'proteinId': 'ENSP00000413641',
-  'category': 'missense',
-  'geneId': 'ENSG00000135953',
-  'hgvsp': 'ENSP00000413641.1:p.Leu48del',
-  'majorConsequence': 'frameshift_variant',
-  'consequenceTerms': [
-    'frameshift_variant',
-    'inframe_deletion',
-    'NMD_transcript_variant'
-  ]
-}
+SAMPLE_IDS = ["NA19679", "NA19675_1", "NA19678", "HG00731", "HG00732", "HG00733"]
 
-ES_VARIANTS = [
-    {
-        'alt': 'T',
-        'chrom': '1',
-        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000002_2'],
-        'genotypes': {
-            'I000007_na20870': {
-                'ab': 1, 'ad': None, 'gq': 99, 'sampleId': 'NA20870', 'numAlt': 2, 'dp': 74, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            }
-        },
-        'genomeVersion': '37',
-        'genotypeFilters': '',
-        'hgmd': {'accession': None, 'class': None},
-        'liftedOverChrom': None,
-        'liftedOverGenomeVersion': None,
-        'liftedOverPos': None,
-        'mainTranscriptId': TRANSCRIPT_3['transcriptId'],
-        'originalAltAlleles': ['T'],
-        'populations': {
-            'callset': {'an': 32, 'ac': 2, 'hom': None, 'af': 0.063, 'hemi': None, 'filter_af': None},
-            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'gnomad_genomes': {'an': 30946, 'ac': 4, 'hom': 0, 'af': 0.00012925741614425127, 'hemi': 0,
-                               'filter_af': 0.000437},
-            'exac': {'an': 121308, 'ac': 8, 'hom': 0, 'af': 0.00006589, 'hemi': 0, 'filter_af': 0.0006726888333653661},
-            'gnomad_exomes': {'an': 245930, 'ac': 16, 'hom': 0, 'af': 0.00006505916317651364, 'hemi': 0,
-                              'filter_af': 0.0009151523074911753},
-            'topmed': {'an': 125568, 'ac': 21, 'hom': 0, 'af': 0.00016724, 'hemi': 0, 'filter_af': None},
-            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
-        },
-        'pos': 248203925,
-        'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
-                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
-                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
-        'ref': 'TC',
-        'rsid': None,
-        'transcripts': {
-            'ENSG00000135953': [TRANSCRIPT_3],
-            'ENSG00000228198': [TRANSCRIPT_2],
-        },
-        'variantId': '1-248203925-TC-T',
-        'xpos': 1248203925,
-        'end': None,
-        'svType': None,
-        'numExon': None,
-        '_sort': [1248203925],
-    },
-    {
-        'alt': 'G',
-        'chrom': '2',
-        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000001_1', 'F000003_3'],
-        'genotypes': {
-            'I000004_hg00731': {
-                'ab': 0, 'ad': None, 'gq': 99, 'sampleId': 'HG00731', 'numAlt': 0, 'dp': 67, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000005_hg00732': {
-                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00732', 'numAlt': 2, 'dp': 42, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000006_hg00733': {
-                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00733', 'numAlt': 1, 'dp': 42, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000007_na20870': {
-                'ab': 0.70212764, 'ad': None, 'gq': 46, 'sampleId': 'NA20870', 'numAlt': 1, 'dp': 50, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            }
-        },
-        'genotypeFilters': '',
-        'genomeVersion': '37',
-        'hgmd': {'accession': None, 'class': None},
-        'liftedOverGenomeVersion': None,
-        'liftedOverChrom': None,
-        'liftedOverPos': None,
-        'mainTranscriptId': TRANSCRIPT_1['transcriptId'],
-        'originalAltAlleles': ['G'],
-        'populations': {
-            'callset': {'an': 32, 'ac': 1, 'hom': None, 'af': 0.031, 'hemi': None, 'filter_af': None},
-            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'gnomad_genomes': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'exac': {'an': 121336, 'ac': 6, 'hom': 0, 'af': 0.00004942, 'hemi': 0, 'filter_af': 0.000242306760358614},
-            'gnomad_exomes': {'an': 245714, 'ac': 6, 'hom': 0, 'af': 0.000024418633044922146, 'hemi': 0,
-                              'filter_af': 0.00016269686320447742},
-            'topmed': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
-        },
-        'pos': 3339582,
-        'predictions': {
-            'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
-            'dann': None, 'sift': None, 'cadd': 17.26, 'metasvm': None, 'primate_ai': None, 'gerp_rs': None,
-            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
-        },
-        'ref': 'GAGA',
-        'rsid': None,
-        'transcripts': {
-            'ENSG00000135953': [TRANSCRIPT_1],
-            'ENSG00000228198': [TRANSCRIPT_2],
-        },
-        'variantId': '2-003339582-GAGA-G',
-        'xpos': 2003339582,
-        'end': None,
-        'svType': None,
-        'numExon': None,
-        '_sort': [2003339582],
-    },
-]
-
-SINGLE_ES_VARIANTS = [
-    {
-        'alt': 'C',
-        'chrom': '1',
-        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000002_2', 'F000003_3'],
-        'genotypes': {
-            'I000007_na20870': {
-                'ab': 1, 'ad': None, 'gq': 99, 'sampleId': 'NA20870', 'numAlt': 2, 'dp': 74, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            }
-        },
-        'genomeVersion': '37',
-        'genotypeFilters': '',
-        'hgmd': {'accession': None, 'class': None},
-        'liftedOverChrom': None,
-        'liftedOverGenomeVersion': None,
-        'liftedOverPos': None,
-        'mainTranscriptId': TRANSCRIPT_3['transcriptId'],
-        'originalAltAlleles': ['T'],
-        'populations': {
-            'callset': {'an': 32, 'ac': 2, 'hom': None, 'af': 0.063, 'hemi': None, 'filter_af': None},
-            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'gnomad_genomes': {'an': 30946, 'ac': 4, 'hom': 0, 'af': 0.00012925741614425127, 'hemi': 0,
-                               'filter_af': 0.000437},
-            'exac': {'an': 121308, 'ac': 8, 'hom': 0, 'af': 0.00006589, 'hemi': 0, 'filter_af': 0.0006726888333653661},
-            'gnomad_exomes': {'an': 245930, 'ac': 16, 'hom': 0, 'af': 0.00006505916317651364, 'hemi': 0,
-                              'filter_af': 0.0009151523074911753},
-            'topmed': {'an': 125568, 'ac': 21, 'hom': 0, 'af': 0.00016724, 'hemi': 0, 'filter_af': None},
-            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
-        },
-        'pos': 248203925,
-        'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
-                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
-                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
-        'ref': 'TC',
-        'rsid': None,
-        'transcripts': {
-            'ENSG00000135953': [TRANSCRIPT_3],
-            'ENSG00000228198': [TRANSCRIPT_2],
-        },
-        'variantId': '1-248203925-TC-T',
-        'xpos': 1248203925,
-        'end': None,
-        'svType': None,
-        'numExon': None,
-        '_sort': [1248203925],
-    },
-    {
-        'alt': 'G',
-        'chrom': '2',
-        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
-        'familyGuids': ['F000001_1', 'F000002_2', 'F000003_3'],
-        'genotypes': {
-            'I000004_hg00731': {
-                'ab': 0, 'ad': None, 'gq': 99, 'sampleId': 'HG00731', 'numAlt': 0, 'dp': 67, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000005_hg00732': {
-                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00732', 'numAlt': 2, 'dp': 42, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000006_hg00733': {
-                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00733', 'numAlt': 1, 'dp': 42, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            },
-            'I000007_na20870': {
-                'ab': 0.70212764, 'ad': None, 'gq': 46, 'sampleId': 'NA20870', 'numAlt': 1, 'dp': 50, 'pl': None,
-                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
-            }
-        },
-        'genotypeFilters': '',
-        'genomeVersion': '37',
-        'hgmd': {'accession': None, 'class': None},
-        'liftedOverGenomeVersion': None,
-        'liftedOverChrom': None,
-        'liftedOverPos': None,
-        'mainTranscriptId': TRANSCRIPT_1['transcriptId'],
-        'originalAltAlleles': ['G'],
-        'populations': {
-            'callset': {'an': 32, 'ac': 1, 'hom': None, 'af': 0.031, 'hemi': None, 'filter_af': None},
-            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'gnomad_genomes': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'exac': {'an': 121336, 'ac': 6, 'hom': 0, 'af': 0.00004942, 'hemi': 0, 'filter_af': 0.000242306760358614},
-            'gnomad_exomes': {'an': 245714, 'ac': 6, 'hom': 0, 'af': 0.000024418633044922146, 'hemi': 0,
-                              'filter_af': 0.00016269686320447742},
-            'topmed': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
-            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
-        },
-        'pos': 3339582,
-        'predictions': {
-            'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
-            'dann': None, 'sift': None, 'cadd': 17.26, 'metasvm': None, 'primate_ai': None, 'gerp_rs': None,
-            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
-        },
-        'ref': 'GAGA',
-        'rsid': None,
-        'transcripts': {
-            'ENSG00000135953': [TRANSCRIPT_1],
-            'ENSG00000228198': [TRANSCRIPT_2],
-        },
-        'variantId': '2-003339582-GAGA-G',
-        'xpos': 2003339582,
-        'end': None,
-        'svType': None,
-        'numExon': None,
-        '_sort': [2003339582],
-    },
-]
+liftover_to_38 = LiftOver('hg19', 'hg38')
 
 
+# To create a none return value for the variant at pos 1562437
+def mock_convert_coordinate(chrom, pos):
+    if pos == 1562437:
+        return
+    return liftover_to_38.convert_coordinate(chrom, pos)
+
+@mock.patch('seqr.management.commands.lift_project_to_hg38.logger')
 class LiftProjectToHg38Test(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch.object(__builtin__, 'raw_input')
-    @mock.patch('logging.getLogger')
-    @mock.patch('seqr.views.utils.dataset_utils.get_elasticsearch_index_samples')
-    @mock.patch('seqr.utils.elasticsearch.utils.get_es_variants_for_variant_tuples')
-    @mock.patch('seqr.utils.elasticsearch.utils.get_single_es_variant')
-    def test_command(self, mock_single_es_variants, mock_get_es_variants, mock_get_es_samples, mock_getLogger, mock_input):
-        mock_logger = mock_getLogger.return_value
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
+    def test_command(self, mock_get_es_variants, mock_get_es_samples, mock_input, mock_logger):
         mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
-        mock_get_es_variants.return_value = ES_VARIANTS
-        mock_single_es_variants.side_effect = SINGLE_ES_VARIANTS
+        mock_get_es_variants.return_value = VARIANTS
         mock_input.return_value = 'y'
         call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                      '--es-index={}'.format(ELASTICSEARCH_INDEX))
@@ -349,9 +49,179 @@ class LiftProjectToHg38Test(TestCase):
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index'),
             mock.call('Lifting over 4 variants (skipping 0 that are already lifted)'),
-            mock.call('Successfully lifted over 2 variants'),
-            mock.call('Successfully updated 2 variants'),
+            mock.call('Successfully lifted over 3 variants'),
+            mock.call('Successfully updated 3 variants'),
             mock.call('---Done---'),
-            mock.call('Succesfully lifted over 2 variants. Skipped 2 failed variants. Family data not updated for 0 variants')
+            mock.call('Succesfully lifted over 3 variants. Skipped 4 failed variants. Family data not updated for 0 variants')
         ]
         mock_logger.info.assert_has_calls(calls)
+
+        mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
+        mock_get_es_variants.assert_called_with(mock.ANY, [(1001627057, u'G', u'C'), (1046394160, u'G', u'A'), (1248203925, u'TC', u'T'), (2003339582, u'GAGA', u'G')])
+
+        # Test discontinue on lifted variants
+        mock_logger.reset_mock()
+        mock_input.return_value = 'n'
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'Error: found 1 saved variants already on Hg38')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
+    def test_command_error_unmatched_sample(self, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = ['ID_NOT_EXIST'], INDEX_METADATA
+
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'Matches not found for ES sample ids: ID_NOT_EXIST.')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index')
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
+
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.Individual')
+    def test_command_error_missing_indvididuals(self, mock_Individual, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
+
+        mock_ind = mock_Individual.objects.filter.return_value
+        mock_exclude_ind = mock_ind.exclude.return_value
+        family = Family.objects.get(pk=1)
+        mock_exclude_ind.select_related.return_value = [Individual.objects.create(family = family, individual_id = "NO_MATCHED_SAMPLE_IND_ID")]
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'The following families are included in the callset but are missing some family members: 1 (NO_MATCHED_SAMPLE_IND_ID).')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
+
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.SavedVariant')
+    def test_command_error_missing_families(self, mock_SavedVariant, mock_get_es_samples, mock_logger):
+        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
+
+        saved_variants = SavedVariant.objects.filter(pk__in=[1,2,6])
+        mock_SavedVariant.objects.filter.return_value = saved_variants
+
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'The following families have saved variants but are missing from the callset: 11.')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX)
+
+    @mock.patch.object(__builtin__, 'raw_input')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_elasticsearch_index_samples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_single_es_variant')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
+    def test_command_other_exceptions(self, mock_liftover, mock_single_es_variants,
+            mock_get_es_variants, mock_get_es_samples, mock_input, mock_logger):
+        mock_get_es_samples.return_value = VARIANTS, INDEX_METADATA
+
+        # Test discontinue on a failed lift
+        mock_liftover_to_38 = mock_liftover.return_value
+        mock_liftover_to_38.convert_coordinate.side_effect = mock_convert_coordinate
+        mock_input.side_effect = ['y', 'n']
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'Error: unable to lift over 1 variants')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)')
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        calls = [
+            mock.call("chr1", 1562437),
+            mock.call("chr1", 248367227),
+            mock.call("chr1", 46859832),
+        ]
+        mock_liftover_to_38.convert_coordinate.assert_has_calls(calls, any_order = True)
+
+        # Test discontinue on failure of finding a variant in the index
+        mock_get_es_variants.return_value = VARIANTS[:1]
+        mock_logger.reset_mock()
+        mock_input.side_effect = ['y', 'y', 'n']
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'Error: unable to find 1 lifted-over variants')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)')
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        mock_get_es_variants.assert_called_with(mock.ANY, [(1046394160, u'G', u'A'), (1248203925, u'TC', u'T')])
+
+        # Test discontinue on missing family data while updating the saved variants
+        mock_logger.reset_mock()
+        mock_input.side_effect = ['y', 'y', 'y', 'n']
+        with self.assertRaises(CommandError) as ce:
+            call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                    '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        self.assertEqual(ce.exception.message, 'Error: unable to find family data for lifted over variant')
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)'),
+            mock.call('Successfully lifted over 1 variants')
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        mock_single_es_variants.return_value = VARIANTS[1]
+        mock_logger.reset_mock()
+        mock_input.side_effect = ['y', 'y', 'y', 'y']
+        call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index'),
+            mock.call('Lifting over 3 variants (skipping 1 that are already lifted)'),
+            mock.call('Successfully lifted over 1 variants'),
+            mock.call('Successfully updated 1 variants'),
+            mock.call('---Done---'),
+            mock.call('Succesfully lifted over 1 variants. Skipped 2 failed variants. Family data not updated for 1 variants')
+        ]
+        mock_logger.info.assert_has_calls(calls)
+
+        families = [f for f in Family.objects.filter(pk=1)]
+        mock_single_es_variants.assert_called_with(families, '1-248367227-G-A', return_all_queried_families=True)

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -16,18 +16,220 @@ INDEX_METADATA = {
                 }
 SAMPLE_IDS = ["NA19679", "NA19675_1", "NA19678", "HG00731", "HG00732", "HG00732", "HG00733"]
 
+TRANSCRIPT_1 = {
+  'aminoAcids': 'LL/L',
+  'biotype': 'protein_coding',
+  'lof': None,
+  'lofFlags': None,
+  'majorConsequenceRank': 10,
+  'codons': 'ctTCTc/ctc',
+  'geneSymbol': 'MFSD9',
+  'domains': [
+    'Transmembrane_helices:TMhelix',
+    'PROSITE_profiles:PS50850',
+  ],
+  'canonical': 1,
+  'transcriptRank': 0,
+  'cdnaEnd': 421,
+  'lofFilter': None,
+  'hgvs': 'ENSP00000258436.5:p.Leu126del',
+  'hgvsc': 'ENST00000258436.5:c.375_377delTCT',
+  'cdnaStart': 419,
+  'transcriptId': 'ENST00000258436',
+  'proteinId': 'ENSP00000258436',
+  'category': 'missense',
+  'geneId': 'ENSG00000135953',
+  'hgvsp': 'ENSP00000258436.5:p.Leu126del',
+  'majorConsequence': 'inframe_deletion',
+  'consequenceTerms': [
+    'inframe_deletion'
+  ]
+}
+TRANSCRIPT_2 = {
+  'aminoAcids': 'P/X',
+  'biotype': 'protein_coding',
+  'lof': None,
+  'lofFlags': None,
+  'majorConsequenceRank': 4,
+  'codons': 'Ccc/cc',
+  'geneSymbol': 'OR2M3',
+  'domains': [
+    'Transmembrane_helices:TMhelix',
+    'Prints_domain:PR00237',
+  ],
+  'canonical': 1,
+  'transcriptRank': 0,
+  'cdnaEnd': 897,
+  'lofFilter': None,
+  'hgvs': 'ENSP00000389625.1:p.Leu288SerfsTer10',
+  'hgvsc': 'ENST00000456743.1:c.862delC',
+  'cdnaStart': 897,
+  'transcriptId': 'ENST00000456743',
+  'proteinId': 'ENSP00000389625',
+  'category': 'lof',
+  'geneId': 'ENSG00000228198',
+  'hgvsp': 'ENSP00000389625.1:p.Leu288SerfsTer10',
+  'majorConsequence': 'frameshift_variant',
+  'consequenceTerms': [
+    'frameshift_variant'
+  ]
+}
+TRANSCRIPT_3 = {
+  'aminoAcids': 'LL/L',
+  'biotype': 'nonsense_mediated_decay',
+  'lof': None,
+  'lofFlags': None,
+  'majorConsequenceRank': 10,
+  'codons': 'ctTCTc/ctc',
+  'geneSymbol': 'MFSD9',
+  'domains': [
+    'Transmembrane_helices:TMhelix',
+    'Gene3D:1',
+  ],
+  'canonical': None,
+  'transcriptRank': 1,
+  'cdnaEnd': 143,
+  'lofFilter': None,
+  'hgvs': 'ENSP00000413641.1:p.Leu48del',
+  'hgvsc': 'ENST00000428085.1:c.141_143delTCT',
+  'cdnaStart': 141,
+  'transcriptId': 'ENST00000428085',
+  'proteinId': 'ENSP00000413641',
+  'category': 'missense',
+  'geneId': 'ENSG00000135953',
+  'hgvsp': 'ENSP00000413641.1:p.Leu48del',
+  'majorConsequence': 'frameshift_variant',
+  'consequenceTerms': [
+    'frameshift_variant',
+    'inframe_deletion',
+    'NMD_transcript_variant'
+  ]
+}
+
+ES_VARIANTS = [
+    {
+        'alt': 'T',
+        'chrom': '1',
+        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
+        'familyGuids': ['F000003_3'],
+        'genotypes': {
+            'I000007_na20870': {
+                'ab': 1, 'ad': None, 'gq': 99, 'sampleId': 'NA20870', 'numAlt': 2, 'dp': 74, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            }
+        },
+        'genomeVersion': '37',
+        'genotypeFilters': '',
+        'hgmd': {'accession': None, 'class': None},
+        'liftedOverChrom': None,
+        'liftedOverGenomeVersion': None,
+        'liftedOverPos': None,
+        'mainTranscriptId': TRANSCRIPT_3['transcriptId'],
+        'originalAltAlleles': ['T'],
+        'populations': {
+            'callset': {'an': 32, 'ac': 2, 'hom': None, 'af': 0.063, 'hemi': None, 'filter_af': None},
+            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'gnomad_genomes': {'an': 30946, 'ac': 4, 'hom': 0, 'af': 0.00012925741614425127, 'hemi': 0,
+                               'filter_af': 0.000437},
+            'exac': {'an': 121308, 'ac': 8, 'hom': 0, 'af': 0.00006589, 'hemi': 0, 'filter_af': 0.0006726888333653661},
+            'gnomad_exomes': {'an': 245930, 'ac': 16, 'hom': 0, 'af': 0.00006505916317651364, 'hemi': 0,
+                              'filter_af': 0.0009151523074911753},
+            'topmed': {'an': 125568, 'ac': 21, 'hom': 0, 'af': 0.00016724, 'hemi': 0, 'filter_af': None},
+            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
+        },
+        'pos': 248367227,
+        'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
+                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
+                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
+        'ref': 'TC',
+        'rsid': None,
+        'transcripts': {
+            'ENSG00000135953': [TRANSCRIPT_3],
+            'ENSG00000228198': [TRANSCRIPT_2],
+        },
+        'variantId': '1-248367227-TC-T',
+        'xpos': 1248367227,
+        'end': None,
+        'svType': None,
+        'numExon': None,
+        '_sort': [1248367227],
+    },
+    {
+        'alt': 'G',
+        'chrom': '2',
+        'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None},
+        'familyGuids': ['F000002_2', 'F000003_3'],
+        'genotypes': {
+            'I000004_hg00731': {
+                'ab': 0, 'ad': None, 'gq': 99, 'sampleId': 'HG00731', 'numAlt': 0, 'dp': 67, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000005_hg00732': {
+                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00732', 'numAlt': 2, 'dp': 42, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000006_hg00733': {
+                'ab': 0, 'ad': None, 'gq': 96, 'sampleId': 'HG00733', 'numAlt': 1, 'dp': 42, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            },
+            'I000007_na20870': {
+                'ab': 0.70212764, 'ad': None, 'gq': 46, 'sampleId': 'NA20870', 'numAlt': 1, 'dp': 50, 'pl': None,
+                'cn': 2, 'end': None, 'start': None, 'numExon': None, 'defragged': None, 'qs': None,
+            }
+        },
+        'genotypeFilters': '',
+        'genomeVersion': '37',
+        'hgmd': {'accession': None, 'class': None},
+        'liftedOverGenomeVersion': None,
+        'liftedOverChrom': None,
+        'liftedOverPos': None,
+        'mainTranscriptId': TRANSCRIPT_1['transcriptId'],
+        'originalAltAlleles': ['G'],
+        'populations': {
+            'callset': {'an': 32, 'ac': 1, 'hom': None, 'af': 0.031, 'hemi': None, 'filter_af': None},
+            'g1k': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'gnomad_genomes': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'exac': {'an': 121336, 'ac': 6, 'hom': 0, 'af': 0.00004942, 'hemi': 0, 'filter_af': 0.000242306760358614},
+            'gnomad_exomes': {'an': 245714, 'ac': 6, 'hom': 0, 'af': 0.000024418633044922146, 'hemi': 0,
+                              'filter_af': 0.00016269686320447742},
+            'topmed': {'an': 0, 'ac': 0, 'hom': 0, 'af': 0.0, 'hemi': 0, 'filter_af': None},
+            'sv_callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None},
+        },
+        'pos': 103343353,
+        'predictions': {
+            'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
+            'dann': None, 'sift': None, 'cadd': 17.26, 'metasvm': None, 'primate_ai': None, 'gerp_rs': None,
+            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
+        },
+        'ref': 'GAGA',
+        'rsid': None,
+        'transcripts': {
+            'ENSG00000135953': [TRANSCRIPT_1],
+            'ENSG00000228198': [TRANSCRIPT_2],
+        },
+        'variantId': '2-103343353-GAGA-G',
+        'xpos': 2103343353,
+        'end': None,
+        'svType': None,
+        'numExon': None,
+        '_sort': [2103343353],
+    },
+]
+
 
 class LiftProjectToHg38Test(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch('logging.getLogger')
     @mock.patch('seqr.views.utils.dataset_utils.get_elasticsearch_index_samples')
-    def test_command(self, mock_get_es_samples, mock_getLogger):
+    @mock.patch('seqr.utils.elasticsearch.utils.get_es_variants_for_variant_tuples')
+    def test_command(self, mock_get_es_variants, mock_get_es_samples, mock_getLogger):
         logger = mock_getLogger.return_value
         mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
+        mock_get_es_variants.return_value = ES_VARIANTS
         call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
                      '--es-index={}'.format(ELASTICSEARCH_INDEX))
-
+        
         calls = [
             mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
             mock.call('Validating es index test_index')

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -34,8 +34,7 @@ LIFT_MAP = {
 
 def mock_convert_coordinate(chrom, pos):
     pos = int(chrom.replace('chr', ''))*int(1e9) + pos
-    if pos in LIFT_MAP.keys():
-        return(LIFT_MAP[pos])
+    return(LIFT_MAP[pos])
 
 
 @mock.patch('seqr.management.commands.lift_project_to_hg38.logger')

--- a/seqr/management/commands/lift_project_to_hg38_tests.py
+++ b/seqr/management/commands/lift_project_to_hg38_tests.py
@@ -1,0 +1,35 @@
+#-*- coding: utf-8 -*-
+import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+PROJECT_NAME = u'1kg project n\u00e5me with uni\u00e7\u00f8de'
+PROJECT_GUID = 'R0001_1kg'
+ELASTICSEARCH_INDEX = 'test_index'
+INDEX_METADATA = {
+                    "gencodeVersion": "25",
+                    "hail_version": "0.2.24",
+                    "genomeVersion": "38",
+                    "sampleType": "WES",
+                    "sourceFilePath": "test_index_alias_1_path.vcf.gz",
+                }
+SAMPLE_IDS = ["NA19679", "NA19675_1", "NA19678", "HG00731", "HG00732", "HG00732", "HG00733"]
+
+
+class LiftProjectToHg38Test(TestCase):
+    fixtures = ['users', '1kg_project']
+
+    @mock.patch('logging.getLogger')
+    @mock.patch('seqr.views.utils.dataset_utils.get_elasticsearch_index_samples')
+    def test_command(self, mock_get_es_samples, mock_getLogger):
+        logger = mock_getLogger.return_value
+        mock_get_es_samples.return_value = SAMPLE_IDS, INDEX_METADATA
+        call_command('lift_project_to_hg38', u'--project={}'.format(PROJECT_NAME),
+                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
+
+        calls = [
+            mock.call(u'Updating project genome version for {}'.format(PROJECT_NAME)),
+            mock.call('Validating es index test_index')
+        ]
+        logger.info.assert_has_calls(calls)

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -11,32 +11,14 @@ from seqr.views.apis.locus_list_api import add_project_locus_lists
 from seqr.views.apis.variant_search_api import query_variants_handler, query_single_variant_handler, \
     export_variants_handler, search_context_handler, get_saved_search_handler, create_saved_search_handler, \
     update_saved_search_handler, delete_saved_search_handler, get_variant_gene_breakdown
-from seqr.views.utils.test_utils import _check_login, login_non_staff_user
-
+from seqr.views.utils.test_utils import _check_login, login_non_staff_user, VARIANTS
 
 LOCUS_LIST_GUID = 'LL00049_pid_genes_autosomal_do'
 PROJECT_GUID = 'R0001_1kg'
 SEARCH_HASH = 'd380ed0fd28c3127d07a64ea2ba907d7'
 SEARCH = {'filters': {}, 'inheritance': None}
 PROJECT_FAMILIES = [{'projectGuid': PROJECT_GUID, 'familyGuids': ['F000001_1', 'F000002_2']}]
-VARIANTS = [
-    {'alt': 'G', 'ref': 'GAGA', 'chrom': '21', 'pos': 3343400, 'xpos': 2103343400, 'genomeVersion': '38',
-     'liftedOverChrom': '21', 'liftedOverPos': 3343353, 'liftedOverGenomeVersion': '37', 'variantId': '21-3343400-GAGA-G',
-     'mainTranscriptId': 'ENST00000623083', 'transcripts': {'ENSG00000227232': [{'aminoAcids': 'G/S', 'geneSymbol': 'WASH7P',
-     'biotype': 'protein_coding', 'category': 'missense', 'cdnaEnd': 1075, 'cdnaStart': 1075, 'codons': 'Ggt/Agt',
-     'consequenceTerms': ['missense_variant'], 'hgvs': 'ENSP00000485442.1:p.Gly359Ser', 'hgvsc': 'ENST00000623083.3:c.1075G>A',
-     'hgvsp': 'ENSP00000485442.1:p.Gly359Ser', 'majorConsequence': 'missense_variant', 'majorConsequenceRank': 11,
-     'proteinId': 'ENSP00000485442', 'transcriptId': 'ENST00000623083', 'transcriptRank': 0}], 'ENSG00000268903': [{
-     'aminoAcids': 'G/S', 'biotype': 'protein_coding', 'category': 'missense', 'cdnaEnd': 1338, 'cdnaStart': 1338,
-     'codons': 'Ggt/Agt', 'consequenceTerms': ['missense_variant'], 'geneId': 'ENSG00000268903', 'hgvs': 'ENSP00000485351.1:p.Gly368Ser',
-     'hgvsc': 'ENST00000624735.1:c.1102G>A', 'hgvsp': 'ENSP00000485351.1:p.Gly368Ser', 'majorConsequence': 'missense_variant',
-     'majorConsequenceRank': 11, 'proteinId': 'ENSP00000485351', 'transcriptId': 'ENST00000624735', 'transcriptRank': 1}]
-     }, 'familyGuids': ['F000001_1', 'F000002_2'],
-     'genotypes': {'NA19675': {'sampleId': 'NA19675', 'ab': 0.7021276595744681, 'gq': 46.0, 'numAlt': 1, 'dp': '50', 'ad': '14,33'},
-                   'NA19679': {'sampleId': 'NA19679', 'ab': 0.0, 'gq': 99.0, 'numAlt': 0, 'dp': '45', 'ad': '45,0'}}},
-    {'alt': 'A', 'ref': 'AAAG', 'chrom': '3', 'pos': 835, 'xpos': 3000000835, 'genomeVersion': '37', 'liftedOverGenomeVersion': '', 'variantId': '3-835-AAAG-A', 'transcripts': {}, 'familyGuids': ['F000001_1'], 'genotypes': {'NA19679': {'sampleId': 'NA19679', 'ab': 0.0, 'gq': 99.0, 'numAlt': 0, 'dp': '45', 'ad': '45,0'}}},
-    {'alt': 'T', 'ref': 'TC', 'chrom': '12', 'pos': 48367227, 'xpos': 1248367227, 'genomeVersion': '37', 'liftedOverGenomeVersion': '', 'variantId': '12-48367227-TC-T', 'transcripts': {'ENSG00000233653': {}}, 'familyGuids': ['F000002_2'], 'genotypes': {}},
-]
+
 VARIANTS_WITH_DISCOVERY_TAGS = deepcopy(VARIANTS)
 VARIANTS_WITH_DISCOVERY_TAGS[2]['discoveryTags'] = [{
     'savedVariant': {

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -124,7 +124,7 @@ VARIANTS = [
         'ref': 'GAGA',
         'chrom': '21',
         'pos': 3343400,
-        'xpos': 2103343400,
+        'xpos': 21003343400,
         'genomeVersion': '38',
         'liftedOverChrom': '21',
         'liftedOverPos': 3343353,
@@ -229,3 +229,17 @@ VARIANTS = [
         'genotypes': {}
     }
 ]
+
+SINGLE_VARIANT = {
+    'alt': 'A',
+    'ref': 'G',
+    'chrom': '1',
+    'pos': 46394160,
+    'xpos': 1046394160,
+    'genomeVersion': '38',
+    'liftedOverGenomeVersion': '37',
+    'variantId': '1-46394160-G-A',
+    'transcripts': {'ENSG00000233653': {}},
+    'familyGuids': ['F000002_2'],
+    'genotypes': {}
+}

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -117,3 +117,115 @@ GENE_DETAIL_FIELDS = {
     'constraints', 'diseaseDesc', 'functionDesc', 'notes', 'omimPhenotypes', 'mimNumber', 'mgiMarkerId', 'geneNames',
 }
 GENE_DETAIL_FIELDS.update(GENE_FIELDS)
+
+VARIANTS = [
+    {
+        'alt': 'G',
+        'ref': 'GAGA',
+        'chrom': '21',
+        'pos': 3343400,
+        'xpos': 2103343400,
+        'genomeVersion': '38',
+        'liftedOverChrom': '21',
+        'liftedOverPos': 3343353,
+        'liftedOverGenomeVersion': '37',
+        'variantId': '21-3343400-GAGA-G',
+        'mainTranscriptId': 'ENST00000623083',
+        'transcripts': {
+            'ENSG00000227232': [
+                {
+                    'aminoAcids': 'G/S',
+                    'geneSymbol': 'WASH7P',
+                    'biotype': 'protein_coding',
+                    'category': 'missense',
+                    'cdnaEnd': 1075,
+                    'cdnaStart': 1075,
+                    'codons': 'Ggt/Agt',
+                    'consequenceTerms': ['missense_variant'],
+                    'hgvs': 'ENSP00000485442.1:p.Gly359Ser',
+                    'hgvsc': 'ENST00000623083.3:c.1075G>A',
+                    'hgvsp': 'ENSP00000485442.1:p.Gly359Ser',
+                    'majorConsequence': 'missense_variant',
+                    'majorConsequenceRank': 11,
+                    'proteinId': 'ENSP00000485442',
+                    'transcriptId': 'ENST00000623083',
+                    'transcriptRank': 0
+                }
+            ],
+            'ENSG00000268903': [
+                {
+                    'aminoAcids': 'G/S',
+                    'biotype': 'protein_coding',
+                    'category': 'missense',
+                    'cdnaEnd': 1338,
+                    'cdnaStart': 1338,
+                    'codons': 'Ggt/Agt',
+                    'consequenceTerms': ['missense_variant'],
+                    'geneId': 'ENSG00000268903',
+                    'hgvs': 'ENSP00000485351.1:p.Gly368Ser',
+                    'hgvsc': 'ENST00000624735.1:c.1102G>A',
+                    'hgvsp': 'ENSP00000485351.1:p.Gly368Ser',
+                    'majorConsequence': 'missense_variant',
+                    'majorConsequenceRank': 11,
+                    'proteinId': 'ENSP00000485351',
+                    'transcriptId': 'ENST00000624735',
+                    'transcriptRank': 1
+                }
+            ]
+        },
+        'familyGuids': ['F000001_1', 'F000002_2'],
+        'genotypes': {
+            'NA19675': {
+                'sampleId': 'NA19675',
+                'ab': 0.7021276595744681,
+                'gq': 46.0,
+                'numAlt': 1,
+                'dp': '50',
+                'ad': '14,33'
+            },
+            'NA19679': {
+                'sampleId': 'NA19679',
+                'ab': 0.0,
+                'gq': 99.0,
+                'numAlt': 0,
+                'dp': '45',
+                'ad': '45,0'
+            }
+        }
+    },
+    {
+        'alt': 'A',
+        'ref': 'AAAG',
+        'chrom': '3',
+        'pos': 835,
+        'xpos': 3000000835,
+        'genomeVersion': '37',
+        'liftedOverGenomeVersion': '',
+        'variantId': '3-835-AAAG-A',
+        'transcripts': {},
+        'familyGuids': ['F000001_1'],
+        'genotypes': {
+            'NA19679': {
+                'sampleId': 'NA19679',
+                'ab': 0.0,
+                'gq': 99.0,
+                'numAlt': 0,
+                'dp': '45',
+                'ad': '45,0'
+            }
+        }
+    },
+    {
+        'alt': 'T',
+        'ref': 'TC',
+        'chrom': '12',
+        'pos': 48367227,
+        'xpos': 1248367227,
+        'genomeVersion': '37',
+        'liftedOverGenomeVersion': '',
+        'variantId': '12-48367227-TC-T',
+        'transcripts': {'ENSG00000233653': {}},
+        'familyGuids': ['F000002_2'],
+        'genotypes': {}
+    }
+]


### PR DESCRIPTION
Added a test for the basic features of lift_project_to_hg38. Exception tests are not included.
The lift_project_to_hg38.py was modified to fixed a unicode issue and a argument mismatch issue of the _update_variant_samples() method.