### PR TITLE
fix failure to use custom configured ES port

### DIFF
--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -2,7 +2,7 @@ import elasticsearch
 from elasticsearch_dsl import Q
 import logging
 
-from settings import ELASTICSEARCH_SERVICE_HOSTNAME
+from settings import ELASTICSEARCH_SERVICE_HOSTNAME, ELASTICSEARCH_PORT
 from seqr.models import Sample
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_set_json
 from seqr.utils.elasticsearch.constants import XPOS_SORT_KEY, VARIANT_DOC_TYPE, SV_DOC_TYPE
@@ -19,7 +19,7 @@ class InvalidIndexException(Exception):
 
 
 def get_es_client(timeout=60):
-    return elasticsearch.Elasticsearch(hosts=[{"host": settings.ELASTICSEARCH_SERVICE_HOSTNAME, "port": settings.ELASTICSEARCH_PORT}],  timeout=timeout)
+    return elasticsearch.Elasticsearch(hosts=[{"host": ELASTICSEARCH_SERVICE_HOSTNAME, "port": ELASTICSEARCH_PORT}],  timeout=timeout)
 
 def get_index_metadata(index_name, client):
     cache_key = 'index_metadata__{}'.format(index_name)

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -19,8 +19,7 @@ class InvalidIndexException(Exception):
 
 
 def get_es_client(timeout=60):
-    return elasticsearch.Elasticsearch(host=ELASTICSEARCH_SERVICE_HOSTNAME, timeout=timeout)
-
+    return elasticsearch.Elasticsearch(hosts=[{"host": settings.ELASTICSEARCH_SERVICE_HOSTNAME, "port": settings.ELASTICSEARCH_PORT}],  timeout=timeout)
 
 def get_index_metadata(index_name, client):
     cache_key = 'index_metadata__{}'.format(index_name)


### PR DESCRIPTION
I found that even if I set ELASTICSEARCH_PORT in the django `settings.py`, SeqR would still try to query on port 9200. I tracked it down to the ElasticSearch constructor, which only uses the hostname and doesn't pass the port through. This change corrected the problem for me.