### PR TITLE
Added unit tests for download_file method.

### DIFF
--- a/reference_data/management/commands/utils/download_utils.py
+++ b/reference_data/management/commands/utils/download_utils.py
@@ -19,7 +19,7 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
     if not (url and url.startswith(("http://", "https://", "ftp://"))):
         raise ValueError("Invalid url: {}".format(url))
     local_file_path = os.path.join(to_dir, os.path.basename(url))
-    remote_file_size = get_remote_file_size(url)
+    remote_file_size = _get_remote_file_size(url)
     if os.path.isfile(local_file_path) and os.path.getsize(local_file_path) == remote_file_size:
         logger.info("Re-using {} previously downloaded from {}".format(local_file_path, url))
         return local_file_path
@@ -37,12 +37,10 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
     return local_file_path
 
 
-def get_remote_file_size(url):
+def _get_remote_file_size(url):
     if url.startswith("http"):
         response = requests.head(url)
         return int(response.headers.get('Content-Length', '0'))
-    elif url.startswith("ftp"):
-        return 0  # file size not yet implemented for FTP
     else:
-        raise ValueError("Invalid url: {}".format(url))
+        return 0  # file size not yet implemented for FTP and other protocols
 

--- a/reference_data/management/commands/utils/download_utils_tests.py
+++ b/reference_data/management/commands/utils/download_utils_tests.py
@@ -1,0 +1,56 @@
+import mock
+import responses
+
+import tempfile
+import shutil
+
+from reference_data.management.commands.utils.download_utils import download_file
+
+from django.test import TestCase
+
+
+class DownloadUtilsTest(TestCase):
+
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Close the file, the directory will be removed after the test
+        shutil.rmtree(self.test_dir)
+
+    @responses.activate
+    @mock.patch('reference_data.management.commands.utils.download_utils.logger')
+    @mock.patch('reference_data.management.commands.utils.download_utils.os.path.isfile')
+    @mock.patch('reference_data.management.commands.utils.download_utils.os.path.getsize')
+    @mock.patch('reference_data.management.commands.utils.download_utils.urllib')
+    def test_download_file(self, mock_urllib, mock_getsize, mock_isfile, mock_logger):
+
+        # Test bad url
+        with self.assertRaises(ValueError) as ve:
+            download_file("bad_url")
+        self.assertEqual(ve.exception.message, "Invalid url: bad_url")
+
+        # Test already downloaded
+        responses.add(responses.HEAD, 'https://mock_url/test_file.gz',
+                      headers={"Content-Length": "1024"}, status=200)
+        responses.add(responses.HEAD, 'ftp://mock_url/test_file.txt',
+                      headers={"Content-Length": "1024"}, status=200)
+        mock_isfile.return_value = True
+        mock_getsize.return_value = 1024
+        result = download_file('https://mock_url/test_file.gz')
+        mock_logger.info.assert_called_with('Re-using {} previously downloaded from https://mock_url/test_file.gz'.format(result))
+
+        mock_isfile.return_value = False
+        mock_getsize.return_value = 0
+        mock_logger.reset_mock()
+        mock_urllib.urlopen.return_value = "test data\nanother line\n"
+        result = download_file('ftp://mock_url/test_file.txt', self.test_dir)
+        mock_logger.info.assert_called_with("Downloading ftp://mock_url/test_file.txt to {}/test_file.txt".format(self.test_dir))
+        self.assertEqual(result, "{}/test_file.txt".format(self.test_dir))
+
+        with open("{}/test_file.txt".format(self.test_dir), 'r') as f:
+            line1 = f.readline()
+            line2 = f.readline()
+        self.assertEqual(line1, "test data\n")
+        self.assertEqual(line2, "another line\n")

--- a/reference_data/management/commands/utils/download_utils_tests.py
+++ b/reference_data/management/commands/utils/download_utils_tests.py
@@ -47,6 +47,7 @@ class DownloadUtilsTest(TestCase):
         mock_urllib.urlopen.return_value = "test data\nanother line\n"
         result = download_file('ftp://mock_url/test_file.txt', self.test_dir)
         mock_logger.info.assert_called_with("Downloading ftp://mock_url/test_file.txt to {}/test_file.txt".format(self.test_dir))
+        mock_urllib.urlopen.assert_called_with('ftp://mock_url/test_file.txt')
         self.assertEqual(result, "{}/test_file.txt".format(self.test_dir))
 
         with open("{}/test_file.txt".format(self.test_dir), 'r') as f:


### PR DESCRIPTION
Nodes for review:
1. The `tempfile` in the parameter `def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):` can't be mocked because the default value of the parameter is generated before mocking being run. So I leave it un-mocked.
2. The exception in line #47 of `reference_data/management/commands/utils/download_utils.py` is un-reachable.
3. It seems that `responses` cannot mock the `urllib`. So the `urllib.urlopen()` is mocked separately.