### PR TITLE
fix reload saved variants calls

### DIFF
--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -3,7 +3,7 @@ import mock
 
 from django.core.management import call_command
 from django.test import TestCase
-from seqr.models import Project, Family
+from seqr.models import Family
 
 PROJECT_NAME = u'1kg project n\u00e5me with uni\u00e7\u00f8de'
 PROJECT_GUID = 'R0001_1kg'

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -3,11 +3,10 @@ import mock
 
 from django.core.management import call_command
 from django.test import TestCase
-from seqr.models import Project
+from seqr.models import Project, Family
 
 PROJECT_NAME = u'1kg project n\u00e5me with uni\u00e7\u00f8de'
 PROJECT_GUID = 'R0001_1kg'
-SAVED_VARIANT_GUIDS = ['SV0000001_2103343353_r0390_100', 'SV0000002_1248367227_r0390_100']
 FAMILY_ID = '1'
 
 
@@ -15,9 +14,11 @@ class ReloadSavedVariantJsonTest(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch('logging.getLogger')
-    @mock.patch('seqr.views.utils.variant_utils.update_project_saved_variant_json')
-    def test_with_param_command(self, mock_update_json, mock_get_logger):
-        mock_update_json.return_value = SAVED_VARIANT_GUIDS
+    @mock.patch('seqr.views.utils.variant_utils.get_es_variants_for_variant_ids')
+    def test_with_param_command(self, mock_get_variants, mock_get_logger):
+        mock_get_variants.side_effect = lambda families, variant_ids: \
+            [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}
+             for variant_id in variant_ids]
         mock_logger = mock_get_logger.return_value
 
         # Test with a specific project and a family id.
@@ -25,52 +26,56 @@ class ReloadSavedVariantJsonTest(TestCase):
                      PROJECT_NAME,
                      '--family-id={}'.format(FAMILY_ID))
 
-        project = Project.objects.get(name__exact = PROJECT_NAME)
-        mock_update_json.assert_called_with(project, family_id=FAMILY_ID)
+        mock_get_variants.assert_called_with(
+            set(Family.objects.filter(id=1)), {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C'})
 
         logger_info_calls = [
             mock.call(u'Project: 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call(u'Updated 2 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
+            mock.call(u'Updated 3 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Done'),
             mock.call('Summary: '),
-            mock.call(u'  1kg project n\xe5me with uni\xe7\xf8de: Updated 2 variants')
+            mock.call(u'  1kg project n\xe5me with uni\xe7\xf8de: Updated 3 variants')
         ]
         mock_logger.info.assert_has_calls(logger_info_calls)
-        mock_update_json.reset_mock()
+        mock_get_variants.reset_mock()
         mock_logger.reset_mock()
 
         # Test for all projects and no specific family ids
         call_command('reload_saved_variant_json')
 
-        projects = Project.objects.all()
-        calls = [mock.call(project, family_id=None) for project in projects]
-        mock_update_json.assert_has_calls(calls, any_order = True)
+        self.assertEqual(mock_get_variants.call_count, 2)
+        mock_get_variants.assert_has_calls([
+            mock.call(
+                set(Family.objects.filter(id__in=[1, 2])),
+                {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C', '12-48367227-TC-T'},
+            ),
+            mock.call(set(Family.objects.filter(id=11)), {'12-48367227-TC-T'})
+        ], any_order=True)
 
         logger_info_calls = [
             mock.call(u'Project: 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call(u'Updated 2 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
+            mock.call(u'Updated 4 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call(u'Project: Empty Project'),
-            mock.call(u'Updated 2 variants for project Empty Project'),
+            mock.call(u'Updated 0 variants for project Empty Project'),
             mock.call(u'Project: Test Project'),
-            mock.call(u'Updated 2 variants for project Test Project'),
+            mock.call(u'Updated 1 variants for project Test Project'),
             mock.call('Done'),
             mock.call('Summary: '),
-            mock.call(u'  1kg project n\xe5me with uni\xe7\xf8de: Updated 2 variants'),
-            mock.call(u'  Empty Project: Updated 2 variants'),
-            mock.call(u'  Test Project: Updated 2 variants')
+            mock.call(u'  1kg project n\xe5me with uni\xe7\xf8de: Updated 4 variants'),
+            mock.call(u'  Test Project: Updated 1 variants')
         ]
         mock_logger.info.assert_has_calls(logger_info_calls)
-        mock_update_json.reset_mock()
+        mock_get_variants.reset_mock()
         mock_logger.reset_mock()
 
         # Test with an exception.
-        mock_update_json.side_effect = Exception("Database error.")
+        mock_get_variants.side_effect = Exception("Database error.")
         call_command('reload_saved_variant_json',
                      PROJECT_GUID,
                      '--family-id={}'.format(FAMILY_ID))
 
-        project = Project.objects.get(guid__exact = PROJECT_GUID)
-        mock_update_json.assert_called_with(project, family_id=FAMILY_ID)
+        mock_get_variants.assert_called_with(
+            set(Family.objects.filter(id=1)), {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C'})
 
         logger_info_calls = [
             mock.call(u'Project: 1kg project n\xe5me with uni\xe7\xf8de'),

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from seqr.models import Family, Sample, VariantSearch, VariantSearchResults
 from seqr.utils.elasticsearch.utils import get_es_variants_for_variant_tuples, get_single_es_variant, get_es_variants, \
-    get_es_variant_gene_counts
+    get_es_variant_gene_counts, get_es_variants_for_variant_ids
 from seqr.utils.elasticsearch.es_search import _get_family_affected_status
 
 INDEX_NAME = 'test_index'
@@ -1206,6 +1206,13 @@ class EsUtilsTest(TestCase):
 
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['2-103343353-GAGA-G', '1-248367227-TC-T']}}],
+        )
+
+    def test_get_es_variants_for_variant_ids(self):
+        get_es_variants_for_variant_ids(self.families, ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL'])
+        self.assertExecutedSearch(
+            filters=[{'terms': {'variantId': ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL']}}],
+            size=6, index=','.join([INDEX_NAME, SV_INDEX_NAME]),
         )
 
     def test_get_single_es_variant(self):

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -51,6 +51,13 @@ def get_single_es_variant(families, variant_id, return_all_queried_families=Fals
     return variants[0]
 
 
+def get_es_variants_for_variant_ids(families, variant_ids, dataset_type=None):
+    variants = EsSearch(families).filter_by_location(variant_ids=variant_ids)
+    if dataset_type:
+        variants = variants.update_dataset_type(dataset_type)
+    return variants.search(num_results=len(variant_ids))
+
+
 def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
     variant_ids = []
     for xpos, ref, alt in xpos_ref_alt_tuples:
@@ -58,9 +65,7 @@ def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
         if chrom == 'M':
             chrom = 'MT'
         variant_ids.append('{}-{}-{}-{}'.format(chrom, pos, ref, alt))
-    variants = EsSearch(families).filter_by_location(variant_ids=variant_ids).update_dataset_type(
-        Sample.DATASET_TYPE_VARIANT_CALLS).search(num_results=len(xpos_ref_alt_tuples))
-    return variants
+    return get_es_variants_for_variant_ids(families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
 
 def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, **kwargs):

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -674,10 +674,11 @@ class SavedVariantAPITest(TransactionTestCase):
             {vt.functional_data_tag for vt in variant_functional_data})
         self.assertSetEqual({"An updated note", "0.05"}, {vt.metadata for vt in variant_functional_data})
 
-    @mock.patch('seqr.views.utils.variant_utils._retrieve_saved_variants_json')
-    def test_update_saved_variant_json(self, mock_retrieve_variants):
-        mock_retrieve_variants.side_effect = lambda project, variant_tuples: \
-            [{'variantId': var[0], 'familyGuids': [var[1].guid]} for var in variant_tuples]
+    @mock.patch('seqr.views.utils.variant_utils.get_es_variants_for_variant_ids')
+    def test_update_saved_variant_json(self, mock_get_variants):
+        mock_get_variants.side_effect = lambda families, variant_ids: \
+            [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}
+             for variant_id in variant_ids]
 
         url = reverse(update_saved_variant_json, args=['R0001_1kg'])
         _check_login(self, url)


### PR DESCRIPTION
Due to the way a utility function was mocked out and the inputs to the mocked calls were never properly tested, the functionality for reloading variants has been broken for a while. This fixes and refactors that code, and increases the test coverage so it won't happen again

Reloading saved variants happens in the background when a dataset is updated, and as such it will fail silently and not have much of a noticeable effect when broken, which is why this was missed