### PR TITLE
Converted seqr management command add_project_tag to Python3.

### DIFF
--- a/seqr/management/commands/add_project_tag.py
+++ b/seqr/management/commands/add_project_tag.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models.query_utils import Q
 

--- a/seqr/management/tests/add_project_tag_2_3_tests.py
+++ b/seqr/management/tests/add_project_tag_2_3_tests.py
@@ -45,20 +45,23 @@ class AddProjectTagTest(TestCase):
         out = StringIO()
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag', stdout = out)
-        self.assertRegex(str(err.exception), 'Error:.*argument.*--project')
+        self.assertIn(str(err.exception), ['Error: argument --project is required',
+             'Error: the following arguments are required: --project, --name, --order'])
 
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag',
                 '--project={}'.format(TAG_ARGUMENTS["project"]),
                 stdout = out)
-        self.assertRegex(str(err.exception), 'Error:.*argument.*--name')
+        self.assertIn(str(err.exception), ['Error: argument --name is required',
+             'Error: the following arguments are required: --name, --order'])
 
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag',
                 '--project={}'.format(TAG_ARGUMENTS["project"]),
                 '--name={}'.format(TAG_ARGUMENTS["name"]),
                 stdout = out)
-        self.assertRegex(str(err.exception), 'Error:.*argument.*--order')
+        self.assertIn(str(err.exception), ['Error: argument --order is required',
+             'Error: the following arguments are required: --order'])
 
     def test_bad_argument_value(self):
         out = StringIO()

--- a/seqr/management/tests/add_project_tag_tests.py
+++ b/seqr/management/tests/add_project_tag_tests.py
@@ -45,20 +45,20 @@ class AddProjectTagTest(TestCase):
         out = StringIO()
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag', stdout = out)
-        self.assertEqual(err.exception.message, 'Error: argument --project is required')
+        self.assertRegex(str(err.exception), 'Error:.*argument.*--project')
 
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag',
                 '--project={}'.format(TAG_ARGUMENTS["project"]),
                 stdout = out)
-        self.assertEqual(err.exception.message, 'Error: argument --name is required')
+        self.assertRegex(str(err.exception), 'Error:.*argument.*--name')
 
         with self.assertRaises(CommandError) as err:
             call_command('add_project_tag',
                 '--project={}'.format(TAG_ARGUMENTS["project"]),
                 '--name={}'.format(TAG_ARGUMENTS["name"]),
                 stdout = out)
-        self.assertEqual(err.exception.message, 'Error: argument --order is required')
+        self.assertRegex(str(err.exception), 'Error:.*argument.*--order')
 
     def test_bad_argument_value(self):
         out = StringIO()
@@ -68,4 +68,4 @@ class AddProjectTagTest(TestCase):
                 '--category={}'.format(TAG_ARGUMENTS["category"]),
                 '--description={}'.format(TAG_ARGUMENTS["description"]),
                 '--color={}'.format(TAG_ARGUMENTS["color"]), stdout = out)
-        self.assertEqual(err.exception.message, 'Tag "Tier 1 - Novel gene and phenotype" already exists for project Test Project')
+        self.assertEqual(str(err.exception), 'Tag "Tier 1 - Novel gene and phenotype" already exists for project Test Project')


### PR DESCRIPTION
Changes:
1. Add `from __future__ import unicode_literals` to convert all str literals to unicode
2. Change the exception result tests to accommodate the error message differences between the Django libraries of Python2 and 3.
  - Python 2 exception: 'Error: argument --project is required'
  - Python 3 exception: 'Error: the following arguments are required: --name, --order'
  Use regular expression assertion to avoid incompatibility between Python 2 and 3.