### PR TITLE
Converted locus_list_api to Python 2 and 3 compatible.

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -211,11 +211,11 @@ api_endpoints = {
 
     'hpo_terms/(?P<hpo_parent_id>[^/]+)': get_hpo_terms,
 
-    'locus_lists': locus_lists,
-    'locus_lists/(?P<locus_list_guid>[^/]+)': locus_list_info,
-    'locus_lists/create': create_locus_list_handler,
     'locus_lists/(?P<locus_list_guid>[^/]+)/update': update_locus_list_handler,
     'locus_lists/(?P<locus_list_guid>[^/]+)/delete': delete_locus_list_handler,
+    'locus_lists/create': create_locus_list_handler,
+    'locus_lists/(?P<locus_list_guid>[^/]+)': locus_list_info,
+    'locus_lists': locus_lists,
     'project/(?P<project_guid>[^/]+)/add_locus_lists': add_project_locus_lists,
     'project/(?P<project_guid>[^/]+)/delete_locus_lists': delete_project_locus_lists,
 

--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import logging
 

--- a/seqr/views/apis/locus_list_api_2_3_tests.py
+++ b/seqr/views/apis/locus_list_api_2_3_tests.py
@@ -1,3 +1,5 @@
+# from __future__ import unicode_literals
+
 import json
 import mock
 
@@ -49,7 +51,7 @@ class LocusListAPITest(AuthenticationTestCase):
 
         response_json = response.json()
         locus_lists_dict = response_json['locusListsByGuid']
-        self.assertListEqual(locus_lists_dict.keys(), [LOCUS_LIST_GUID])
+        self.assertListEqual(list(locus_lists_dict.keys()), [LOCUS_LIST_GUID])
 
         locus_list = locus_lists_dict[LOCUS_LIST_GUID]
         self.assertSetEqual(set(locus_list.keys()), LOCUS_LIST_DETAIL_FIELDS)
@@ -67,7 +69,7 @@ class LocusListAPITest(AuthenticationTestCase):
 
         response_json = response.json()
         locus_lists_dict = response_json['locusListsByGuid']
-        self.assertListEqual(locus_lists_dict.keys(), [PRIVATE_LOCUS_LIST_GUID])
+        self.assertListEqual(list(locus_lists_dict.keys()), [PRIVATE_LOCUS_LIST_GUID])
 
     def test_create_locus_list(self):
         create_locus_list_url = reverse(create_locus_list_handler)
@@ -93,7 +95,7 @@ class LocusListAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         new_locus_list_response = response.json()
         self.assertEqual(len(new_locus_list_response['locusListsByGuid']), 1)
-        new_locus_list = new_locus_list_response['locusListsByGuid'].values()[0]
+        new_locus_list = list(new_locus_list_response['locusListsByGuid'].values())[0]
         self.assertEqual(new_locus_list['name'], 'new_locus_list')
         self.assertEqual(new_locus_list['isPublic'], True)
 
@@ -142,7 +144,7 @@ class LocusListAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         updated_locus_list_response = response.json()
         self.assertEqual(len(updated_locus_list_response['locusListsByGuid']), 1)
-        updated_locus_list = updated_locus_list_response['locusListsByGuid'].values()[0]
+        updated_locus_list = list(updated_locus_list_response['locusListsByGuid'].values())[0]
         self.assertEqual(updated_locus_list['name'], 'updated_locus_list')
         self.assertEqual(updated_locus_list['isPublic'], False)
 

--- a/seqr/views/apis/locus_list_api_2_3_tests.py
+++ b/seqr/views/apis/locus_list_api_2_3_tests.py
@@ -1,9 +1,8 @@
-# from __future__ import unicode_literals
+from __future__ import unicode_literals
 
 import json
 import mock
 
-from django.test import TransactionTestCase
 from django.urls.base import reverse
 
 from seqr.models import LocusList


### PR DESCRIPTION
One thing weird is that the Python 3 Django doesn't do longest url matching. It is solved by reordering the url entries. No change to the urls other locus_list_api yet.