### PR TITLE
Pedigree parsing unit test coverage

### DIFF
--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -64,7 +64,7 @@ def parse_pedigree_table(parsed_file, filename, user=None, project=None):
             if expected == actual:
                 expected = expected_header_columns[4:6]
                 actual = headers[1][4:6]
-            unexpected_header_columns = "\t".join(difflib.unified_diff(expected, actual)).split("\n")[3:]
+            unexpected_header_columns = '|'.join(difflib.unified_diff(expected, actual)).split('\n')[3:]
             if unexpected_header_columns:
                 raise ValueError("Expected vs. actual header columns: {}".format("\t".join(unexpected_header_columns)))
 
@@ -302,19 +302,6 @@ def _is_header_row(row):
     """
     row = row.lower()
     if "family" in row and ("indiv" in row or "datstat" in row):
-        return True
-    else:
-        return False
-
-
-def _is_merged_pedigree_sample_manifest_header_row(header_row):
-    """Checks whether these rows are from a file that contains columns from the Broad's sample manifest + pedigree table.
-    See #_parse_merged_pedigree_sample_manifest_format docs for format details.
-
-    Args:
-        row (string): The 1st row in the file
-    """
-    if "kit id" in header_row.lower() and "sample id" in header_row.lower():
         return True
     else:
         return False

--- a/seqr/views/utils/pedigree_info_utils_tests.py
+++ b/seqr/views/utils/pedigree_info_utils_tests.py
@@ -63,12 +63,13 @@ class PedigreeInfoUtilsTest(TestCase):
 
         records, errors, warnings = parse_pedigree_table(
             [['family_id', 'individual_id', 'sex', 'affected', 'father', 'mother', 'proband_relation'],
-             ['fam1', 'ind1', 'male', 'aff.', 'ind3', 'ind2', 'mother'], ['fam2', 'ind2', 'male', 'u', '.', '', '']],
+             ['fam1', 'ind1', 'male', 'aff.', 'ind3', 'ind2', 'mother'],
+             ['fam2', 'ind2', 'male', 'unknown', '.', '', '']],
             FILENAME)
         self.assertListEqual(records, [
             {'familyId': 'fam1', 'individualId': 'ind1', 'sex': 'M', 'affected': 'A', 'paternalId': 'ind3',
              'maternalId': 'ind2', 'probandRelationship': 'M'},
-            {'familyId': 'fam2', 'individualId': 'ind2', 'sex': 'M', 'affected': 'N', 'paternalId': '',
+            {'familyId': 'fam2', 'individualId': 'ind2', 'sex': 'M', 'affected': 'U', 'paternalId': '',
              'maternalId': '', 'probandRelationship': ''},
         ])
         self.assertListEqual(errors, [
@@ -79,14 +80,17 @@ class PedigreeInfoUtilsTest(TestCase):
         self.assertListEqual(warnings, ["ind3 is the father of ind1 but doesn't have a separate record in the table"])
 
         records, errors, warnings = parse_pedigree_table(
-            [['family_id', 'individual_id', 'notes_for_import', 'other_data', 'sex', 'affected', 'father', 'mother', 'phenotype: coded', 'proband_relation'],
-             ['fam1', 'ind1', 'some notes', 'some more notes', 'male', 'aff.', '.', 'ind2', 'HPO:12345', ''],
-             ['fam1', 'ind2', ' ', '', 'female', 'u', '.', '', 'HPO:56789', 'mother']], FILENAME)
+            [['A pedigree file'], ['# Some comments'],
+             ['#family_id', '#individual_id', 'previous_individual_id', 'notes_for_import', 'other_data', 'sex', 'affected', 'father', 'mother', 'phenotype: coded', 'proband_relation'],
+             ['fam1', 'ind1', 'ind1_old_id', 'some notes', 'some more notes', 'male', 'aff.', '.', 'ind2', 'HPO:12345', ''],
+             ['fam1', 'ind2', '', ' ', '', 'female', 'u', '.', '', 'HPO:56789', 'mother']], FILENAME)
         self.assertListEqual(records, [
             {'familyId': 'fam1', 'individualId': 'ind1', 'sex': 'M', 'affected': 'A', 'paternalId': '',
-             'maternalId': 'ind2', 'notes': 'some notes', 'codedPhenotype': 'HPO:12345', 'probandRelationship': ''},
+             'maternalId': 'ind2', 'notes': 'some notes', 'codedPhenotype': 'HPO:12345', 'probandRelationship': '',
+             'previousIndividualId': 'ind1_old_id'},
             {'familyId': 'fam1', 'individualId': 'ind2', 'sex': 'F', 'affected': 'N', 'paternalId': '',
-             'maternalId': '', 'notes': '', 'codedPhenotype': 'HPO:56789', 'probandRelationship': 'M'},
+             'maternalId': '', 'notes': '', 'codedPhenotype': 'HPO:56789', 'probandRelationship': 'M',
+             'previousIndividualId': ''},
         ])
         self.assertListEqual(errors, [])
         self.assertListEqual(warnings, [])


### PR DESCRIPTION
We support a specific type of upload that takes a sample manifest sent by collaborators and parses it to create the corresponding families in seqr but also emails the PM team a parsed version of the file they need for submitting to GP for sequencing. This adds testing for that