### PR TITLE
Converted seqr.utils to be compatible with Python 2 and 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   - python: '2.7'
     env: TEST_PATTERN='*_tests.py' COVERAGE_THRESHHOLD=95
   - python: '3.7'
-    env: TEST_PATTERN='*_2_3_tests.py' COVERAGE_THRESHHOLD=23
+    env: TEST_PATTERN='*_2_3_tests.py' COVERAGE_THRESHHOLD=50
 
 node_js:
 - '11.8.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: node_js
+language: python
 
 jobs:
   include:

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -x
-pip install -r requirements.txt --user --upgrade
-pip install -r requirements-dev.txt --user --upgrade
+pip install -r requirements.txt --upgrade
+pip install -r requirements-dev.txt --upgrade
 cd ui/
 echo -ne "\n \n \3033[1B\nsemantic/\n" | npm install
 cd ..

--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 from slacker import Slacker
 from settings import SLACK_TOKEN, BASE_URL

--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import os
 import subprocess

--- a/seqr/utils/gene_utils.py
+++ b/seqr/utils/gene_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import re
 from collections import defaultdict
 from django.db.models import Q

--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -33,7 +33,7 @@ class JsonErrorMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, exception):
         if request.path.startswith('/api'):
-            exception_json = {'message': str(exception)}
+            exception_json = {'message': exception.args[0]}
             traceback_message = traceback.format_exc()
             logger.error(traceback_message)
             if DEBUG:

--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from builtins import str as unicode_str
+from builtins import str
 
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.utils.deprecation import MiddlewareMixin
@@ -36,10 +36,7 @@ class JsonErrorMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, exception):
         if request.path.startswith('/api'):
-            try:
-                exception_json = {'message': str(exception)}
-            except Exception:
-                exception_json = {'message': unicode_str(exception)}
+            exception_json = {'message': exception.message if hasattr(exception, 'message') else str(exception)}
             traceback_message = traceback.format_exc()
             logger.error(traceback_message)
             if DEBUG:

--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.utils.deprecation import MiddlewareMixin
 from requests import HTTPError
@@ -33,10 +35,10 @@ class JsonErrorMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, exception):
         if request.path.startswith('/api'):
-            exception_json = {'message': exception.args[0]}
+            exception_json = {'message': str(exception)}
             traceback_message = traceback.format_exc()
             logger.error(traceback_message)
             if DEBUG:
-                exception_json['traceback'] = traceback_message.split('\n')
+                    exception_json['traceback'] = traceback_message
             return create_json_response(exception_json, status=_get_exception_status_code(exception))
         return None

--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import str as unicode_str
 
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.utils.deprecation import MiddlewareMixin
@@ -35,7 +36,10 @@ class JsonErrorMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, exception):
         if request.path.startswith('/api'):
-            exception_json = {'message': str(exception)}
+            try:
+                exception_json = {'message': str(exception)}
+            except Exception:
+                exception_json = {'message': unicode_str(exception)}
             traceback_message = traceback.format_exc()
             logger.error(traceback_message)
             if DEBUG:

--- a/seqr/utils/redis_utils.py
+++ b/seqr/utils/redis_utils.py
@@ -17,7 +17,7 @@ def safe_redis_get_json(cache_key):
             logger.info('Loaded {} from redis'.format(cache_key))
             return json.loads(value)
     except ValueError as e:
-        logger.warn('Unable to fetch "{}" from redis: {}'.format(cache_key, str(e)))
+        logger.warn('Unable to fetch "{}" from redis:\t{}'.format(cache_key, str(e)))
     except Exception as e:
         logger.warn('Unable to connect to redis host {}: {}'.format(REDIS_SERVICE_HOSTNAME, str(e)))
     return None

--- a/seqr/utils/redis_utils_2_3_tests.py
+++ b/seqr/utils/redis_utils_2_3_tests.py
@@ -29,7 +29,10 @@ class RedisUtilsTest(TestCase):
         mock_redis.return_value.get.side_effect = lambda key: key
         self.assertIsNone(safe_redis_get_json('test_key'))
         mock_logger.info.assert_called_with('Loaded test_key from redis')
-        mock_logger.warn.assert_called_with('Unable to fetch "test_key" from redis: No JSON object could be decoded')
+        warn_args = str(mock_logger.warn.call_args.args[0])
+        # Python 2 and 3 return different warning when encountering JSON decoding error
+        self.assertIn(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
+                                  'Unable to fetch "test_key" from redis: Expecting value: line 1 column 1 (char 0)'])
 
         # test with redis connection error
         mock_logger.reset_mock()

--- a/seqr/utils/redis_utils_2_3_tests.py
+++ b/seqr/utils/redis_utils_2_3_tests.py
@@ -29,10 +29,7 @@ class RedisUtilsTest(TestCase):
         mock_redis.return_value.get.side_effect = lambda key: key
         self.assertIsNone(safe_redis_get_json('test_key'))
         mock_logger.info.assert_called_with('Loaded test_key from redis')
-        warn_args = str(mock_logger.warn.call_args.args[0])
-        # Python 2 and 3 return different warning when encountering JSON decoding error
-        self.assertIn(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
-                                  'Unable to fetch "test_key" from redis: Expecting value: line 1 column 1 (char 0)'])
+        self.assertEqual(mock_logger.warn.call_args.args[0].split('\t')[0], 'Unable to fetch "test_key" from redis:')
 
         # test with redis connection error
         mock_logger.reset_mock()

--- a/seqr/utils/redis_utils_2_3_tests.py
+++ b/seqr/utils/redis_utils_2_3_tests.py
@@ -29,7 +29,10 @@ class RedisUtilsTest(TestCase):
         mock_redis.return_value.get.side_effect = lambda key: key
         self.assertIsNone(safe_redis_get_json('test_key'))
         mock_logger.info.assert_called_with('Loaded test_key from redis')
-        mock_logger.warn.assert_called_with('Unable to fetch "test_key" from redis: No JSON object could be decoded')
+        warn_args = str(mock_logger.warn.call_args.args[0])
+        # Python 2 and 3 return different warning when encountering JSON decoding error
+        self.assertEqual(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
+                                  'Unable to fetch "test_key" from redis: Expecting value: line 1 column 1 (char 0)'])
 
         # test with redis connection error
         mock_logger.reset_mock()

--- a/seqr/utils/redis_utils_2_3_tests.py
+++ b/seqr/utils/redis_utils_2_3_tests.py
@@ -31,7 +31,7 @@ class RedisUtilsTest(TestCase):
         mock_logger.info.assert_called_with('Loaded test_key from redis')
         warn_args = str(mock_logger.warn.call_args.args[0])
         # Python 2 and 3 return different warning when encountering JSON decoding error
-        self.assertEqual(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
+        self.assertIn(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
                                   'Unable to fetch "test_key" from redis: Expecting value: line 1 column 1 (char 0)'])
 
         # test with redis connection error

--- a/seqr/utils/redis_utils_2_3_tests.py
+++ b/seqr/utils/redis_utils_2_3_tests.py
@@ -29,10 +29,7 @@ class RedisUtilsTest(TestCase):
         mock_redis.return_value.get.side_effect = lambda key: key
         self.assertIsNone(safe_redis_get_json('test_key'))
         mock_logger.info.assert_called_with('Loaded test_key from redis')
-        warn_args = str(mock_logger.warn.call_args.args[0])
-        # Python 2 and 3 return different warning when encountering JSON decoding error
-        self.assertIn(warn_args, ['Unable to fetch "test_key" from redis: No JSON object could be decoded',
-                                  'Unable to fetch "test_key" from redis: Expecting value: line 1 column 1 (char 0)'])
+        mock_logger.warn.assert_called_with('Unable to fetch "test_key" from redis: No JSON object could be decoded')
 
         # test with redis connection error
         mock_logger.reset_mock()

--- a/seqr/utils/xpos_utils.py
+++ b/seqr/utils/xpos_utils.py
@@ -7,6 +7,8 @@ chr1, position 12345 is xpos  1000012345
 chrX, position 23552 is xpos 23000023552
 """
 
+from __future__ import unicode_literals
+
 CHROMOSOMES = [
     '1',
     '2',

--- a/seqr/utils/xpos_utils_2_3_tests.py
+++ b/seqr/utils/xpos_utils_2_3_tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from unittest import TestCase
 from seqr.utils.xpos_utils import get_chrom_pos, get_xpos
 
@@ -23,8 +25,8 @@ class XposUtilsTest(TestCase):
         self.assertRaises(ValueError, lambda: get_chrom_pos(0))
         self.assertRaises(ValueError, lambda: get_chrom_pos(30*1e9))
 
-        self.assertEquals(get_chrom_pos(1e9 + 12345), ('1', 12345))
-        self.assertEquals(get_chrom_pos(22*1e9 + 12345), ('22', 12345))
-        self.assertEquals(get_chrom_pos(23*1e9 + 12345), ('X', 12345))
-        self.assertEquals(get_chrom_pos(24*1e9 + 12345), ('Y', 12345))
-        self.assertEquals(get_chrom_pos(25*1e9 + 12345), ('M', 12345))
+        self.assertEqual(get_chrom_pos(1e9 + 12345), ('1', 12345))
+        self.assertEqual(get_chrom_pos(22*1e9 + 12345), ('22', 12345))
+        self.assertEqual(get_chrom_pos(23*1e9 + 12345), ('X', 12345))
+        self.assertEqual(get_chrom_pos(24*1e9 + 12345), ('Y', 12345))
+        self.assertEqual(get_chrom_pos(25*1e9 + 12345), ('M', 12345))

--- a/seqr/views/apis/staff_api_tests.py
+++ b/seqr/views/apis/staff_api_tests.py
@@ -486,7 +486,7 @@ class StaffAPITest(AuthenticationTestCase):
         url = reverse(mme_details)
         self.check_staff_login(url)
 
-        mock_datetime.now.return_value = datetime(2020, 4, 27, 20, 16, 01)
+        mock_datetime.now.return_value = datetime(2020, 4, 27, 20, 16, 1)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()


### PR DESCRIPTION
I don't add `from __future__ import unicode_literals` to the file `seqr/utils/middleware.py` in purpose. 
If `unicode_literals` is imported then the `'\n'` in `exception_json['traceback'] = traceback_message.split('\n')` at line 40 will become a `unicode` type. In this case, if `traceback_message` is a Python 2 `str` and has unicodes in it, it will be a casting error.