### PR TITLE
Staff gene variants

### DIFF
--- a/seqr/views/apis/staff_api.py
+++ b/seqr/views/apis/staff_api.py
@@ -1222,8 +1222,13 @@ def _update_initial_omim_numbers(rows):
 @staff_member_required(login_url=API_LOGIN_REQUIRED_URL)
 def saved_variants_page(request, tag):
     gene = request.GET.get('gene')
-    tag_type = VariantTagType.objects.get(name=tag, project__isnull=True)
-    saved_variant_models = SavedVariant.objects.filter(varianttag__variant_tag_type=tag_type)
+
+    if tag == 'ALL':
+        saved_variant_models = SavedVariant.objects.exclude(varianttag=None)
+    else:
+        tag_type = VariantTagType.objects.get(name=tag, project__isnull=True)
+        saved_variant_models = SavedVariant.objects.filter(varianttag__variant_tag_type=tag_type)
+
     if gene:
         saved_variant_models = saved_variant_models.filter(saved_variant_json__transcripts__has_key=gene)
     elif saved_variant_models.count() > MAX_SAVED_VARIANTS:

--- a/seqr/views/apis/staff_api_tests.py
+++ b/seqr/views/apis/staff_api_tests.py
@@ -697,15 +697,21 @@ class StaffAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['message'], 'Select a gene to filter variants')
 
-        response = self.client.get('{}?gene=ENSG00000240361'.format(url))
+        response = self.client.get('{}?gene=ENSG00000135953'.format(url))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {
             'projectsByGuid', 'locusListsByGuid', 'savedVariantsByGuid', 'variantFunctionalDataByGuid', 'genesById',
             'variantNotesByGuid', 'individualsByGuid', 'variantTagsByGuid', 'familiesByGuid'})
-        self.assertSetEqual(
-            set(response_json['savedVariantsByGuid'].keys()),
-            {'SV0000007_prefix_19107_DEL_r00', 'SV0000006_1248367227_r0003_tes'})
+        expected_variant_guids = {
+            'SV0000001_2103343353_r0390_100', 'SV0000007_prefix_19107_DEL_r00', 'SV0000006_1248367227_r0003_tes'}
+        self.assertSetEqual(set(response_json['savedVariantsByGuid'].keys()), expected_variant_guids)
+
+        all_tag_url = reverse(saved_variants_page, args=['ALL'])
+        response = self.client.get('{}?gene=ENSG00000135953'.format(all_tag_url))
+        self.assertEqual(response.status_code, 200)
+        expected_variant_guids.add('SV0000002_1248367227_r0390_100')
+        self.assertSetEqual(set(response.json()['savedVariantsByGuid'].keys()), expected_variant_guids)
 
     @mock.patch('seqr.views.apis.staff_api.file_iter')
     def test_upload_qc_pipeline_output(self, mock_file_iter):

--- a/ui/pages/Staff/components/SavedVariants.jsx
+++ b/ui/pages/Staff/components/SavedVariants.jsx
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Route, Switch } from 'react-router-dom'
-import { Form } from 'semantic-ui-react'
+import { Form, Label } from 'semantic-ui-react'
 
+import { getGenesById } from 'redux/selectors'
 import {
   REVIEW_TAG_NAME,
   KNOWN_GENE_FOR_PHENOTYPE_TAG_NAME,
@@ -62,13 +63,15 @@ TAG_OPTIONS.push({
   label: { empty: true, circular: true, style: { backgroundColor: 'white' } },
 })
 
-const BaseStaffSavedVariants = React.memo(({ loadStaffSavedVariants, ...props }) => {
+const BaseStaffSavedVariants = React.memo(({ loadStaffSavedVariants, geneDetail, ...props }) => {
   const { params } = props.match
   const { tag, gene } = params
 
   const getUpdateTagUrl = selectedTag => `/staff/saved_variants/${selectedTag}${gene ? `/${gene}` : ''}`
 
   const getGeneHref = selectedGene => `/staff/saved_variants/${tag || SHOW_ALL}/${selectedGene.key}`
+
+  const removeGene = () => props.history.push(`/staff/saved_variants/${tag || SHOW_ALL}`)
 
   const loadVariants = (newParams) => {
     const isInitialLoad = params === newParams
@@ -99,12 +102,24 @@ const BaseStaffSavedVariants = React.memo(({ loadStaffSavedVariants, ...props })
             getResultHref={getGeneHref}
             inline
           />
+          {gene && <HorizontalSpacer width={10} />}
+          {gene && <Form.Field
+            control={Label}
+            content={(geneDetail || {}).geneSymbol || gene}
+            inline
+            color="grey"
+            onRemove={removeGene}
+          />}
           <HorizontalSpacer width={10} />
         </StyledForm>
       }
       {...props}
     />
   )
+})
+
+const mapStateToProps = (state, ownProps) => ({
+  geneDetail: getGenesById(state)[ownProps.match.params.gene],
 })
 
 const mapDispatchToProps = {
@@ -114,11 +129,13 @@ const mapDispatchToProps = {
 
 BaseStaffSavedVariants.propTypes = {
   match: PropTypes.object,
+  history: PropTypes.object,
+  geneDetail: PropTypes.object,
   updateTable: PropTypes.func,
   loadStaffSavedVariants: PropTypes.func,
 }
 
-const StaffSavedVariants = connect(null, mapDispatchToProps)(BaseStaffSavedVariants)
+const StaffSavedVariants = connect(mapStateToProps, mapDispatchToProps)(BaseStaffSavedVariants)
 
 const RoutedSavedVariants = ({ match }) =>
   <Switch>

--- a/ui/pages/Staff/components/SavedVariants.jsx
+++ b/ui/pages/Staff/components/SavedVariants.jsx
@@ -10,6 +10,7 @@ import {
   VARIANT_SORT_FIELD,
   VARIANT_PER_PAGE_FIELD,
   VARIANT_TAGGED_DATE_FIELD,
+  SHOW_ALL,
 } from 'shared/utils/constants'
 import { StyledForm } from 'shared/components/form/ReduxFormWrapper'
 import AwesomeBar from 'shared/components/page/AwesomeBar'
@@ -54,19 +55,20 @@ const TAG_OPTIONS = [
   label: { empty: true, circular: true, style: { backgroundColor: 'white' } },
 }))
 
-const getUpdateTagUrl = tag => `/staff/saved_variants/${tag}`
+TAG_OPTIONS.push({
+  value: SHOW_ALL,
+  text: 'All',
+  key: 'all',
+  label: { empty: true, circular: true, style: { backgroundColor: 'white' } },
+})
 
 const BaseStaffSavedVariants = React.memo(({ loadStaffSavedVariants, ...props }) => {
   const { params } = props.match
   const { tag, gene } = params
 
-  const getGeneHref = (selectedGene) => {
-    if (!tag) {
-      return props.match.url
-    }
+  const getUpdateTagUrl = selectedTag => `/staff/saved_variants/${selectedTag}${gene ? `/${gene}` : ''}`
 
-    return `/staff/saved_variants${tag ? `/${tag}` : ''}/gene/${selectedGene.key}`
-  }
+  const getGeneHref = selectedGene => `/staff/saved_variants/${tag || SHOW_ALL}/${selectedGene.key}`
 
   const loadVariants = (newParams) => {
     const isInitialLoad = params === newParams
@@ -120,8 +122,7 @@ const StaffSavedVariants = connect(null, mapDispatchToProps)(BaseStaffSavedVaria
 
 const RoutedSavedVariants = ({ match }) =>
   <Switch>
-    <Route path={`${match.url}/:tag/gene/:gene`} component={StaffSavedVariants} />
-    <Route path={`${match.url}/:tag?`} component={StaffSavedVariants} />
+    <Route path={`${match.url}/:tag?/:gene?`} component={StaffSavedVariants} />
   </Switch>
 
 RoutedSavedVariants.propTypes = {

--- a/ui/pages/Staff/reducers.js
+++ b/ui/pages/Staff/reducers.js
@@ -190,7 +190,7 @@ export const loadSavedVariants = ({ tag, gene = '' }) => {
       if (getState().savedVariantTags[tag]) {
         return
       }
-    } else {
+    } else if (!gene) {
       return
     }
 

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -167,7 +167,7 @@ export const getPairedSelectedSavedVariants = createSelector(
   getProjectGuid,
   getVariantTagsByGuid,
   getVariantNotesByGuid,
-  (savedVariants, { tag, familyGuid, analysisGroupGuid, variantGuid }, familiesByGuid, analysisGroupsByGuid, projectGuid, tagsByGuid, notesByGuid) => {
+  (savedVariants, { tag, gene, familyGuid, analysisGroupGuid, variantGuid }, familiesByGuid, analysisGroupsByGuid, projectGuid, tagsByGuid, notesByGuid) => {
     let variants = Object.values(savedVariants)
     if (variantGuid) {
       variants = variants.filter(o => variantGuid.split(',').includes(o.variantGuid))
@@ -214,6 +214,11 @@ export const getPairedSelectedSavedVariants = createSelector(
       }
     }
 
+    if (gene) {
+      pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(
+        ({ transcripts }) => gene in (transcripts || {})))
+    }
+
     return pairedVariants
   },
 )
@@ -223,7 +228,7 @@ export const getPairedFilteredSavedVariants = createSelector(
   getSavedVariantTableState,
   getVariantTagsByGuid,
   (state, props) => props.match.params,
-  (savedVariants, { categoryFilter = SHOW_ALL, hideExcluded, hideReviewOnly, hideKnownGeneForPhenotype, taggedAfter }, tagsByGuid, { tag, gene, variantGuid }) => {
+  (savedVariants, { categoryFilter = SHOW_ALL, hideExcluded, hideReviewOnly, hideKnownGeneForPhenotype, taggedAfter }, tagsByGuid, { tag, variantGuid }) => {
     if (variantGuid) {
       return savedVariants
     }
@@ -247,17 +252,11 @@ export const getPairedFilteredSavedVariants = createSelector(
         variantsToShow = variantsToShow.filter(variants => variants.some(
           variant => variant.tagGuids.some(t => tagsByGuid[t].category === categoryFilter)))
       }
-    } else {
-      if (gene) {
-        variantsToShow = variantsToShow.filter(variants => variants.some(variant => gene in variant.transcripts))
-      }
-
-      if (taggedAfter) {
-        const taggedAfterDate = new Date(taggedAfter)
-        variantsToShow = variantsToShow.filter(variants => variants.some(variant =>
-          variant.tagGuids.find(
-            t => tagsByGuid[t].name === tag && new Date(tagsByGuid[t].lastModifiedDate) > taggedAfterDate)))
-      }
+    } else if (taggedAfter) {
+      const taggedAfterDate = new Date(taggedAfter)
+      variantsToShow = variantsToShow.filter(variants => variants.some(variant =>
+        variant.tagGuids.find(
+          t => tagsByGuid[t].name === tag && new Date(tagsByGuid[t].lastModifiedDate) > taggedAfterDate)))
     }
     return variantsToShow.map(variants => (variants.length === 1 ? variants[0] : variants))
   },

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -209,7 +209,7 @@ export const getPairedSelectedSavedVariants = createSelector(
     if (tag) {
       if (tag === NOTE_TAG_NAME) {
         pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(({ noteGuids }) => noteGuids.length))
-      } else {
+      } else if (tag !== SHOW_ALL) {
         pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(({ tagGuids }) => tagGuids.some(tagGuid => tagsByGuid[tagGuid].name === tag)))
       }
     }

--- a/ui/shared/components/panel/variants/VariantGene.jsx
+++ b/ui/shared/components/panel/variants/VariantGene.jsx
@@ -2,9 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
+import { NavLink } from 'react-router-dom'
 import { Label, Popup, List, Header } from 'semantic-ui-react'
 
-import { getGenesById, getLocusListsByGuid, getCurrentProject } from 'redux/selectors'
+import { getGenesById, getLocusListsByGuid, getCurrentProject, getUser } from 'redux/selectors'
 import { MISSENSE_THRESHHOLD, LOF_THRESHHOLD } from '../../../utils/constants'
 import { HorizontalSpacer, VerticalSpacer } from '../../Spacers'
 import { InlineHeader, ButtonLink } from '../../StyledComponents'
@@ -202,7 +203,7 @@ GeneDetails.propTypes = {
   containerStyle: PropTypes.object,
 }
 
-const BaseVariantGene = React.memo(({ geneId, gene, project, variant, compact, showInlineDetails, areCompoundHets }) => {
+const BaseVariantGene = React.memo(({ geneId, gene, project, user, variant, compact, showInlineDetails, areCompoundHets }) => {
 
   const geneTranscripts = variant.transcripts[geneId]
   const geneConsequence = geneTranscripts && geneTranscripts.length > 0 && (geneTranscripts[0].majorConsequence || '').replace(/_/g, ' ')
@@ -231,6 +232,8 @@ const BaseVariantGene = React.memo(({ geneId, gene, project, variant, compact, s
     summaryDetail = (
       <GeneLinks>
         <a href={`http://gnomad.broadinstitute.org/gene/${gene.geneId}`} target="_blank">gnomAD</a>
+        {user.isStaff && <span><HorizontalSpacer width={5} />|<HorizontalSpacer width={5} /></span>}
+        {user.isStaff && <NavLink to={`/staff/saved_variants/ALL/${gene.geneId}`} target="_blank">seqr</NavLink>}
         {project && <span><HorizontalSpacer width={5} />|<HorizontalSpacer width={5} /></span>}
         {project && <SearchResultsLink geneId={gene.geneId} familyGuids={variant.familyGuids} />}
       </GeneLinks>
@@ -265,6 +268,7 @@ const BaseVariantGene = React.memo(({ geneId, gene, project, variant, compact, s
 BaseVariantGene.propTypes = {
   geneId: PropTypes.string.isRequired,
   project: PropTypes.object,
+  user: PropTypes.object,
   gene: PropTypes.object,
   variant: PropTypes.object.isRequired,
   compact: PropTypes.bool,
@@ -274,6 +278,7 @@ BaseVariantGene.propTypes = {
 
 const mapStateToProps = (state, ownProps) => ({
   project: getCurrentProject(state),
+  user: getUser(state),
   gene: getGenesById(state)[ownProps.geneId],
 })
 


### PR DESCRIPTION
There is a staff-only page where you can see variants tagged across all projects broken down by tag, with the option to filter by gene. This change allows filtering by gene without first needing to select a tag, as requested in https://github.com/macarthur-lab/seqr-private/issues/804

Tis also adds a link to these new pages for staff users next to the gene displayed on variants as requested in https://github.com/macarthur-lab/seqr-private/issues/856