### PR TITLE
Individual update timeout

### DIFF
--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -365,41 +365,56 @@ def _add_or_update_individuals_and_families(project, individual_records, user=No
     Return:
         2-tuple: updated_families, updated_individuals containing Django ORM models
     """
-    families = {}
+    updated_families = set()
     updated_individuals = set()
     parent_updates = []
-    for i, record in enumerate(individual_records):
-        # family id will be in different places in the json depending on whether it comes from a flat uploaded file or from the nested individual object
-        family_id = record.get(JsonConstants.FAMILY_ID_COLUMN) or record.get('family', {})['familyId']
-        family = families.get(family_id)
-        if family:
-            created = False
+
+    family_ids = {_get_record_family_id(record) for record in individual_records}
+    families_by_id = {f.family_id: f for f in Family.objects.filter(project=project, family_id__in=family_ids)}
+
+    missing_family_ids = family_ids - set(families_by_id.keys())
+    for family_id in missing_family_ids:
+        family = Family.objects.create(project=project, family_id=family_id)
+        families_by_id[family_id] = family
+        updated_families.add(family)
+        logger.info('Created family: {}'.format(family))
+
+    individual_models = Individual.objects.filter(family__project=project).prefetch_related(
+        'family', 'mother', 'father')
+    has_individual_guid = any(record.get('individualGuid') for record in individual_records)
+    if has_individual_guid:
+        individual_lookup = {
+            i.guid: i for i in individual_models.filter(
+            guid__in=[record['individualGuid'] for record in individual_records])
+        }
+    else:
+        individual_lookup = defaultdict(dict)
+        for i in individual_models.filter(
+                individual_id__in=[_get_record_individual_id(record) for record in individual_records]):
+            individual_lookup[i.individual_id][i.family] = i
+
+    for record in individual_records:
+        family_id = _get_record_family_id(record)
+        family = families_by_id.get(family_id)
+
+        if has_individual_guid:
+            individual = individual_lookup[record.pop('individualGuid')]
         else:
-            family, created = Family.objects.get_or_create(project=project, family_id=family_id)
-
-        if created:
-            logger.info("Created family: %s", family)
-
-        # uploaded files do not have unique guid's so fall back to a combination of family and individualId
-        if record.get('individualGuid'):
-            individual_filters = {'guid': record['individualGuid']}
-        else:
-            individual_id = record.get(JsonConstants.PREVIOUS_INDIVIDUAL_ID_COLUMN) or record[JsonConstants.INDIVIDUAL_ID_COLUMN]
-            individual_filters = {'family': family, 'individual_id': individual_id}
-
-        individual, created = Individual.objects.get_or_create(**individual_filters)
-
-        if created:
-            record.update({
-                'caseReviewStatus': 'I',
-            })
+            # uploaded files do not have unique guid's so fall back to a combination of family and individualId
+            individual_id = _get_record_individual_id(record)
+            individual = individual_lookup[individual_id].get(family)
+            if not individual:
+                individual = Individual.objects.create(
+                    family=family, individual_id=individual_id, case_review_status='I')
 
         record['family'] = family
         record.pop('familyId', None)
         if individual.family != family:
-            families[individual.family.family_id] = individual.family
+            family = individual.family
+            updated_families.add(family)
 
-        if record.get(JsonConstants.PREVIOUS_INDIVIDUAL_ID_COLUMN):
+        previous_id = record.pop(JsonConstants.PREVIOUS_INDIVIDUAL_ID_COLUMN, None)
+        if previous_id:
             updated_individuals.update(individual.maternal_children.all())
             updated_individuals.update(individual.paternal_children.all())
             record['displayName'] = ''
@@ -412,24 +427,33 @@ def _add_or_update_individuals_and_families(project, individual_records, user=No
                 'paternalId': record.pop('paternalId', None),
             })
 
-        update_individual_from_json(individual, record, allow_unknown_keys=True, user=user)
+        family_notes = record.pop(JsonConstants.FAMILY_NOTES_COLUMN, None)
+        if family_notes:
+            update_family_from_json(family, {'analysis_notes': family_notes})
+            updated_families.add(family)
 
-        if record.get(JsonConstants.FAMILY_NOTES_COLUMN):
-            update_family_from_json(family, {'analysis_notes': record[JsonConstants.FAMILY_NOTES_COLUMN]})
-
-        updated_individuals.add(individual)
-        families[family.family_id] = family
+        is_updated = update_individual_from_json(individual, record, user=user)
+        if is_updated:
+            updated_individuals.add(individual)
+            updated_families.add(family)
 
     for update in parent_updates:
         individual = update.pop('individual')
         update_individual_from_json(individual, update, user=user)
 
-    updated_families = list(families.values())
-
     # update pedigree images
     update_pedigree_images(updated_families, project_guid=project.guid)
 
-    return updated_families, list(updated_individuals)
+    return list(updated_families), list(updated_individuals)
+
+
+def _get_record_family_id(record):
+    # family id will be in different places in the json depending on whether it comes from a flat uploaded file or from the nested individual object
+    return record.get(JsonConstants.FAMILY_ID_COLUMN) or record.get('family', {})['familyId']
+
+
+def _get_record_individual_id(record):
+    return record.get(JsonConstants.PREVIOUS_INDIVIDUAL_ID_COLUMN) or record[JsonConstants.INDIVIDUAL_ID_COLUMN]
 
 
 # Use column keys that align with phenotips fields to support phenotips json export format

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -207,7 +207,14 @@ class IndividualAPITest(AuthenticationTestCase):
         response = self.client.post(individuals_url, {'f': f})
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertListEqual(response_json.keys(), ['info', 'errors', 'warnings', 'uploadedFileId'])
+        self.assertSetEqual(set(response_json.keys()), {'info', 'errors', 'warnings', 'uploadedFileId'})
+        self.assertListEqual(response_json['errors'], [])
+        self.assertListEqual(response_json['warnings'], [])
+        self.assertListEqual(response_json['info'], [
+            '2 families, 3 individuals parsed from 1000_genomes demo_individuals.tsv',
+            '1 new families, 1 new individuals will be added to the project',
+            '2 existing individuals will be updated',
+        ])
 
         url = reverse(save_individuals_table_handler, args=[PROJECT_GUID, response_json['uploadedFileId']])
 
@@ -215,6 +222,24 @@ class IndividualAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'individualsByGuid', 'familiesByGuid'})
+
+        self.assertEqual(len(response_json['familiesByGuid']), 2)
+        self.assertTrue('F000001_1' in response_json['familiesByGuid'])
+        new_family_guid = next(guid for guid in response_json['familiesByGuid'].keys() if guid != 'F000001_1')
+        self.assertEqual(response_json['familiesByGuid'][new_family_guid]['familyId'], '21')
+        self.assertEqual(response_json['familiesByGuid'][new_family_guid]['analysisNotes'], 'a new family')
+
+        self.assertEqual(len(response_json['individualsByGuid']), 3)
+        self.assertTrue('I000001_na19675' in response_json['individualsByGuid'])
+        self.assertTrue('I000002_na19678' in response_json['individualsByGuid'])
+        new_indiv_guid = next(guid for guid in response_json['individualsByGuid'].keys()
+                              if guid not in {'I000001_na19675', 'I000002_na19678'})
+        self.assertEqual(response_json['individualsByGuid']['I000001_na19675']['individualId'], 'NA19675')
+        self.assertEqual(response_json['individualsByGuid']['I000001_na19675']['sex'], 'F')
+        self.assertEqual(
+            response_json['individualsByGuid']['I000001_na19675']['notes'], 'A affected individual, test1-zsf')
+        self.assertEqual(response_json['individualsByGuid'][new_indiv_guid]['individualId'], 'HG00735')
+        self.assertEqual(response_json['individualsByGuid'][new_indiv_guid]['sex'], 'F')
 
     def _is_expected_hpo_upload(self, response):
         self.assertEqual(response.status_code, 200)

--- a/seqr/views/utils/json_to_orm_utils.py
+++ b/seqr/views/utils/json_to_orm_utils.py
@@ -37,7 +37,7 @@ def update_individual_from_json(individual, json, user=None, allow_unknown_keys=
     if json.get('displayName') and json['displayName'] == individual.individual_id:
         json['displayName'] = ''
 
-    update_model_from_json(
+    return update_model_from_json(
         individual, json, user=user, allow_unknown_keys=allow_unknown_keys,
         immutable_keys=[
             'filter_flags', 'pop_platform_filters', 'population',
@@ -58,6 +58,7 @@ def update_model_from_json(model_obj, json, user=None, allow_unknown_keys=False,
     immutable_keys = (immutable_keys or []) + ['created_by', 'created_date', 'last_modified_date', 'id']
     internal_fields = model_obj._meta.internal_json_fields if hasattr(model_obj._meta, 'internal_json_fields') else []
 
+    has_updates = False
     for json_key, value in json.items():
         orm_key = _to_snake_case(json_key)
         if orm_key in immutable_keys:
@@ -69,6 +70,9 @@ def update_model_from_json(model_obj, json, user=None, allow_unknown_keys=False,
         if getattr(model_obj, orm_key) != value:
             if orm_key in internal_fields and not (user and user.is_staff):
                 raise PermissionDenied('User {0} is not authorized to edit the internal field {1}'.format(user, orm_key))
+            has_updates = True
             setattr(model_obj, orm_key, value)
 
-    model_obj.save()
+    if has_updates:
+        model_obj.save()
+    return has_updates


### PR DESCRIPTION
When seqr would receive a bulk update for individuals it would make a database query for each family and each individual that needed updating, which caused it to time out on a 1500 individual update (see https://github.com/macarthur-lab/seqr-private/issues/869). This changes the code to query all the necessary records at once and only make one-record calls to create records, which greatly speeds up this endpoint