### PR TITLE
Fix SV recessive search

### DIFF
--- a/seqr/utils/elasticsearch/constants.py
+++ b/seqr/utils/elasticsearch/constants.py
@@ -26,8 +26,7 @@ GENOTYPE_QUERY_MAP = {
     ALT_ALT: {'allowed_num_alt': ['samples_num_alt_2', 'samples_cn_0', 'samples_cn_2', 'samples_cn_gte_4']},
     HAS_ALT: {'allowed_num_alt': ['samples_num_alt_1', 'samples_num_alt_2', 'samples']},
     HAS_REF: {
-        'not_allowed_num_alt': ['samples_no_call', 'samples_num_alt_2'],
-        'allowed_num_alt': ['samples_cn_1', 'samples_cn_3'],
+        'not_allowed_num_alt': ['samples_no_call', 'samples_num_alt_2', 'samples_cn_0', 'samples_cn_gte_4'],
     },
 }
 

--- a/seqr/utils/elasticsearch/es_utils_2_3_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_2_3_tests.py
@@ -1645,14 +1645,10 @@ class EsUtilsTest(TestCase):
                                             {'term': {'samples_cn_2': 'HG00731'}},
                                             {'term': {'samples_cn_gte_4': 'HG00731'}},
                                         ],
-                                        'must': [{
-                                            'bool': {
-                                                'minimum_should_match': 1,
-                                                'should': [
-                                                    {'term': {'samples_cn_1': 'HG00732'}},
-                                                    {'term': {'samples_cn_3': 'HG00732'}},
-                                                ]}
-                                        }]
+                                        'must_not': [
+                                            {'term': {'samples_cn_0': 'HG00732'}},
+                                            {'term': {'samples_cn_gte_4': 'HG00732'}},
+                                        ]
                                     }},
                                     {'bool': {
                                         'minimum_should_match': 1,
@@ -2448,14 +2444,10 @@ class EsUtilsTest(TestCase):
                     {'term': {'samples_cn_2': 'HG00731'}},
                     {'term': {'samples_cn_gte_4': 'HG00731'}},
                 ],
-                'must': [{
-                    'bool': {
-                        'minimum_should_match': 1,
-                        'should': [
-                            {'term': {'samples_cn_1': 'HG00732'}},
-                            {'term': {'samples_cn_3': 'HG00732'}},
-                    ]}
-                }]
+                'must_not': [
+                    {'term': {'samples_cn_0': 'HG00732'}},
+                    {'term': {'samples_cn_gte_4': 'HG00732'}},
+                ]
             }
         }
         custom_affected_recessive_filter = {


### PR DESCRIPTION
There is a bug with how SV search handles recessive search (https://github.com/macarthur-lab/seqr/issues/1368). This changes the criteria for unaffected individuals in recessive search to match the behavior we want