### PR TITLE
fix multi index search when indices have subset of individuals

### DIFF
--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -65,7 +65,7 @@ class EsSearch(object):
             if len(self.samples_by_family_index) < 1:
                 raise Exception('Inheritance based search is disabled in families with no affected individuals')
 
-        self._indices = sorted(list(self.samples_by_family_index.keys()), reverse = True)
+        self._indices = sorted(list(self.samples_by_family_index.keys()))
         self._set_index_metadata()
 
         if len(self.samples_by_family_index) != len(self.index_metadata):
@@ -208,7 +208,10 @@ class EsSearch(object):
             for index in self._indices:
                 family_samples_by_id = self.samples_by_family_index[index]
                 affected_status = _get_family_affected_status(family_samples_by_id, inheritance_filter)
-                self._family_individual_affected_status.update(affected_status)
+                for family_guid, family_affected_status in affected_status.items():
+                    if family_guid not in self._family_individual_affected_status:
+                        self._family_individual_affected_status[family_guid] = {}
+                    self._family_individual_affected_status[family_guid].update(family_affected_status)
 
         quality_filters_by_family = _quality_filters_by_family(quality_filter, self.samples_by_family_index, self._indices)
 

--- a/seqr/utils/elasticsearch/es_utils_2_3_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_2_3_tests.py
@@ -2072,7 +2072,7 @@ class EsUtilsTest(TestCase):
 
         self.assertExecutedSearch(index=INDEX_NAME, sort=['xpos'], size=6)
         self.mock_es_client.indices.update_aliases.assert_called_with(body={
-            'actions': [{'add': {'indices': [SV_INDEX_NAME, SECOND_INDEX_NAME, INDEX_NAME], 'alias': INDEX_NAME}}]})
+            'actions': [{'add': {'indices': [INDEX_NAME, SECOND_INDEX_NAME, SV_INDEX_NAME], 'alias': INDEX_NAME}}]})
 
     def test_get_es_variant_gene_counts(self):
         search_model = VariantSearch.objects.create(search={


### PR DESCRIPTION
There is a bug in seqr (https://github.com/macarthur-lab/seqr/issues/1367) that occurs if a family has multiple indices containing different individuals. For instance, if the variant index has all 3 individuals, but the SV index only has 2 of them, seqr search gives an unhandled key error. This PR fixes it