### PR TITLE
Fix saved variant sorts

### DIFF
--- a/ui/shared/components/panel/variants/Predictions.jsx
+++ b/ui/shared/components/panel/variants/Predictions.jsx
@@ -22,7 +22,7 @@ const NUM_TO_SHOW_ABOVE_THE_FOLD = 6 // how many predictors to show immediately
 
 const predictionFieldValue = (predictions, { field, dangerThreshold, warningThreshold, indicatorMap, noSeverity }) => {
   let value = predictions[field]
-  if (noSeverity || value === null) {
+  if (noSeverity || value === null || value === undefined) {
     return { value }
   }
 


### PR DESCRIPTION
Some of the sort functions for variants fail and cause page JS errors if the data is sparse, which can happen in normal app use (https://github.com/macarthur-lab/seqr-private/issues/874)