### PR TITLE
Fixed some of Python 3 bugs.

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1130,8 +1130,7 @@
         "name": "Tier 1 - Novel gene and phenotype",
         "category": "CMG Discovery Tags",
         "description": "Gene not previously associated with a Mendelian condition",
-        "color": "#03441E",
-        "order": 1.0
+        "color": "#03441E"
     }
 },
 {

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -94,7 +94,7 @@ class EsSearch(object):
     def _set_index_name(self):
         self.index_name = ','.join(sorted(self._indices))
         if len(self.index_name) > MAX_INDEX_NAME_LENGTH:
-            alias = hashlib.md5(self.index_name).hexdigest()
+            alias = hashlib.md5(self.index_name.encode('utf-8')).hexdigest()
             cache_key = 'index_alias__{}'.format(alias)
             if safe_redis_get_json(cache_key) != self.index_name:
                 self._client.indices.update_aliases(body={'actions': [

--- a/seqr/utils/elasticsearch/es_utils_2_3_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_2_3_tests.py
@@ -16,6 +16,7 @@ from seqr.utils.elasticsearch.utils import get_es_variants_for_variant_tuples, g
 from seqr.utils.elasticsearch.es_search import EsSearch, _get_family_affected_status, _liftover_grch38_to_grch37, \
     _liftover_grch37_to_grch38
 from seqr.views.utils.test_utils import PARSED_VARIANTS, PARSED_SV_VARIANT, TRANSCRIPT_2
+from seqr.utils.redis_utils import safe_redis_get_json
 
 INDEX_NAME = 'test_index'
 SECOND_INDEX_NAME = 'test_index_second'
@@ -831,6 +832,7 @@ def mock_hits(hits, increment_sort=False, include_matched_queries=True, sort=Non
 
 
 def create_mock_response(search, index=INDEX_NAME):
+    index = safe_redis_get_json('index_alias__{}'.format(index)) or index
     indices = index.split(',')
     include_matched_queries = False
     variant_id_filters = None
@@ -2062,21 +2064,20 @@ class EsUtilsTest(TestCase):
         )
 
     @mock.patch('seqr.utils.elasticsearch.es_search.MAX_INDEX_NAME_LENGTH', 30)
-    @mock.patch('seqr.utils.elasticsearch.es_search.hashlib.md5')
-    def test_get_es_variants_index_alias(self, mock_hashlib):
+    def test_get_es_variants_index_alias(self):
         search_model = VariantSearch.objects.create(search={})
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.all())
 
-        mock_hashlib.return_value.hexdigest.return_value = INDEX_NAME
         self.mock_es_client.indices.get_mapping.side_effect = lambda index='': {
             k: {'mappings': v} for k, v in INDEX_METADATA.items()}
 
         get_es_variants(results_model, num_results=2)
 
-        self.assertExecutedSearch(index=INDEX_NAME, sort=['xpos'], size=6)
+        index_name_alias = '236a15db29fc23707a0ec5817ca78b5e'
+        self.assertExecutedSearch(index=index_name_alias, sort=['xpos'], size=6)
         self.mock_es_client.indices.update_aliases.assert_called_with(body={
-            'actions': [{'add': {'indices': [INDEX_NAME, SECOND_INDEX_NAME, SV_INDEX_NAME], 'alias': INDEX_NAME}}]})
+            'actions': [{'add': {'indices': [INDEX_NAME, SECOND_INDEX_NAME, SV_INDEX_NAME], 'alias': index_name_alias}}]})
 
     def test_get_es_variant_gene_counts(self):
         search_model = VariantSearch.objects.create(search={

--- a/seqr/utils/elasticsearch/es_utils_2_3_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_2_3_tests.py
@@ -16,12 +16,12 @@ from seqr.utils.elasticsearch.utils import get_es_variants_for_variant_tuples, g
 from seqr.utils.elasticsearch.es_search import EsSearch, _get_family_affected_status, _liftover_grch38_to_grch37, \
     _liftover_grch37_to_grch38
 from seqr.views.utils.test_utils import PARSED_VARIANTS, PARSED_SV_VARIANT, TRANSCRIPT_2
-from seqr.utils.redis_utils import safe_redis_get_json
 
 INDEX_NAME = 'test_index'
 SECOND_INDEX_NAME = 'test_index_second'
 SV_INDEX_NAME = 'test_index_sv'
 INDEX_ALIAS = '236a15db29fc23707a0ec5817ca78b5e'
+ALIAS_MAP = {INDEX_ALIAS: ','.join([INDEX_NAME, SECOND_INDEX_NAME, SV_INDEX_NAME])}
 
 ES_VARIANTS = [
     {
@@ -833,6 +833,7 @@ def mock_hits(hits, increment_sort=False, include_matched_queries=True, sort=Non
 
 
 def create_mock_response(search, index=INDEX_NAME):
+    index = ALIAS_MAP.get(index, index)
     indices = index.split(',')
     include_matched_queries = False
     variant_id_filters = None
@@ -2071,8 +2072,6 @@ class EsUtilsTest(TestCase):
 
         self.mock_es_client.indices.get_mapping.side_effect = lambda index='': {
             k: {'mappings': v} for k, v in INDEX_METADATA.items()}
-        self.mock_search.side_effect = lambda index=None, body=None, **kwargs: create_mock_response(
-            deepcopy(body), index=','.join([INDEX_NAME, SECOND_INDEX_NAME, SV_INDEX_NAME]))
 
         get_es_variants(results_model, num_results=2)
 

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -306,7 +306,7 @@ def _get_json_for_variant_tag_types(project):
         })
 
     project_variant_tags.append(note_tag_type)
-    project_variant_tags = sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order'])
+    project_variant_tags = sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order'] or 0)
 
     discovery_tag_type_guids = [tag_type['variantTagTypeGuid'] for tag_type in project_variant_tags
                                 if tag_type['category'] == 'CMG Discovery Tags' and tag_type['numTags'] > 0]
@@ -325,7 +325,7 @@ def _get_json_for_variant_tag_types(project):
         } for name, tag_json in tags]
 
     return {
-        'variantTagTypes': sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order']),
+        'variantTagTypes': sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order'] or 0),
         'variantFunctionalTagTypes': get_json_for_variant_functional_data_tag_types(),
         'discoveryTags': discovery_tags,
     }

--- a/seqr/views/apis/staff_api.py
+++ b/seqr/views/apis/staff_api.py
@@ -1260,7 +1260,7 @@ def saved_variants_page(request, tag):
             vt for vt in variant_tags_json if tag_projects.get(vt['variantTagTypeGuid'], project_guid) == project_guid]
         project_json.update({
             'locusListGuids': list(locus_lists_by_guid.keys()),
-            'variantTagTypes': sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order']),
+            'variantTagTypes': sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order'] or 0),
             'variantFunctionalTagTypes': functional_tag_types,
         })
 


### PR DESCRIPTION
The `hashlib.md5()` needs a byte-like parameter such as Python 2 `str` or `bytes`. It can't accept Python 3 `str` which is the same as Python 2 `unicode`. Therefore, encode the Python 3 `str` to `bytes` for the hash function.
Test: open https://seqr-dev.broadinstitute.org/variant_search/results/7c0f4ed48108b4e89966299cbaff7794?page=1&sort=xpos
Without encoding, there will be error `TypeError: Unicode-objects must be encoded before hashing`. After encoding, the error disappears. 

Another issue: Some of the `variant_tag_type` entries don't have an `order` field. In Python 3, it causes an error of `TypeError: '<' not supported between instances of 'NoneType' and 'float'` when sorting a `variant_tag_type` list with the `order` field as a key. Change the key to `variant_tag_type['order'] or 0` to solve the issue.
Test: https://seqr-dev.broadinstitute.org/staff/saved_variants/ALL/ENSG00000196218
Before changing, the page can't be open. It can be open normally after the change.