### PR TITLE
Fixed the issue of missing 'cron'.

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -74,9 +74,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install database clients for debugging (https://www.postgresql.org/download/linux/debian/)
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && curl -L0 -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update && apt-get install -y --no-install-recommends \
+    && apt-get update && apt-get install -y \
         postgresql-12 \
         postgresql-client-12 \
         libpq-dev \


### PR DESCRIPTION
The seqr Python 3 docker container doesn't have the `cron` package installed. By comparing to the sear Python 2 dockerfile, it is figured out that the `cron` package will be installed while installing the `postgresql` package without the option of `--no-install-recommends`. The option is removed to fix the issue.