### PR TITLE
Update redis version

### DIFF
--- a/deploy/docker/redis/Dockerfile
+++ b/deploy/docker/redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:4.0.9
+FROM redis:6.0.6
 
 MAINTAINER MacArthur Lab
 


### PR DESCRIPTION
Bumps the version of redis. To deploy this change, build, push and redeploy the redis pod with the updated version. Note that the deploy command needs to be run with the `-f` force argument to actually rebuild the image properly. This has been tested on dev