### PR TITLE
fix pedigree image saving

### DIFF
--- a/seqr/views/utils/pedigree_image_utils.py
+++ b/seqr/views/utils/pedigree_image_utils.py
@@ -140,7 +140,7 @@ def _update_pedigree_image(family, project_guid=None):
 
 
 def _save_pedigree_image_file(family, png_file_path):
-    with open(png_file_path) as pedigree_image_file:
+    with open(png_file_path, 'rb') as pedigree_image_file:
         family.pedigree_image.save(os.path.basename(png_file_path), File(pedigree_image_file))
         family.save()
 

--- a/seqr/views/utils/pedigree_image_utils.py
+++ b/seqr/views/utils/pedigree_image_utils.py
@@ -88,15 +88,15 @@ def _get_parsed_individuals(family, project_guid=None):
     SEX_TO_FAM_FILE_VALUE = {"M": "1", "F": "2", "U": "0"}
     AFFECTED_STATUS_TO_FAM_FILE_VALUE = {"A": "2", "N": "1", "U": "0", "INVISIBLE": "9"}   # HaploPainter1.043.pl has been modified to hide individuals with affected-status='9'
 
-    return {
-        individual_id: {
+    return [
+        {
             'individualId': individual_id,
-            'paternalId': individual_json['paternalId'] or '0',
-            'maternalId': individual_json['maternalId'] or '0',
-            'sex': SEX_TO_FAM_FILE_VALUE[individual_json['sex']],
-            'affected': AFFECTED_STATUS_TO_FAM_FILE_VALUE[individual_json['affected']],
-        } for individual_id, individual_json in individual_records.items()
-    }
+            'paternalId': individual_records[individual_id]['paternalId'] or '0',
+            'maternalId': individual_records[individual_id]['maternalId'] or '0',
+            'sex': SEX_TO_FAM_FILE_VALUE[individual_records[individual_id]['sex']],
+            'affected': AFFECTED_STATUS_TO_FAM_FILE_VALUE[individual_records[individual_id]['affected']],
+        } for individual_id in sorted(individual_records.keys())
+    ]
 
 
 def _update_pedigree_image(family, project_guid=None):
@@ -116,7 +116,7 @@ def _update_pedigree_image(family, project_guid=None):
     with tempfile.NamedTemporaryFile('w', suffix=".fam", delete=True) as fam_file:
 
         # columns: family, individual id, paternal id, maternal id, sex, affected
-        for i in individual_records.values():
+        for i in individual_records:
             row = [family_id] + [i[key] for key in ['individualId', 'paternalId', 'maternalId', 'sex', 'affected']]
             fam_file.write("\t".join(row))
             fam_file.write("\n")

--- a/seqr/views/utils/pedigree_image_utils_2_3_tests.py
+++ b/seqr/views/utils/pedigree_image_utils_2_3_tests.py
@@ -43,9 +43,9 @@ class PedigreeImageTest(TestCase):
         mock_tempfile_file.write.assert_has_calls([
             mock.call('\t'.join(['1', 'NA19675_1', 'NA19678', 'NA19679', '1', '2'])),
             mock.call('\n'),
-            mock.call('\t'.join(['1', 'NA19679', '0', '0', '2', '1'])),
-            mock.call('\n'),
             mock.call('\t'.join(['1', 'NA19678', '0', '0', '1', '1'])),
+            mock.call('\n'),
+            mock.call('\t'.join(['1', 'NA19679', '0', '0', '2', '1'])),
             mock.call('\n'),
         ])
 
@@ -66,9 +66,9 @@ class PedigreeImageTest(TestCase):
         mock_tempfile_file.write.assert_has_calls([
             mock.call('\t'.join(['1', 'NA19675_1', 'placeholder_123456', 'NA19679', '1', '2'])),
             mock.call('\n'),
-            mock.call('\t'.join(['1', 'placeholder_123456', '0', '0', '1', '9'])),
-            mock.call('\n'),
             mock.call('\t'.join(['1', 'NA19679', '0', '0', '2', '1'])),
+            mock.call('\n'),
+            mock.call('\t'.join(['1', 'placeholder_123456', '0', '0', '1', '9'])),
             mock.call('\n'),
         ])
 

--- a/seqr/views/utils/pedigree_image_utils_2_3_tests.py
+++ b/seqr/views/utils/pedigree_image_utils_2_3_tests.py
@@ -25,8 +25,8 @@ class PedigreeImageTest(TestCase):
         mock_randint.return_value = 123456
 
         def _mock_paint(command):
-            with open(command.split('-outfile ')[-1], 'w') as f:
-                f.write('img')
+            with open(command.split('-outfile ')[-1], 'wb') as f:
+                f.write(b'\xff\xd8\xff')
         mock_os_system.side_effect = _mock_paint
 
         test_families = Family.objects.filter(guid='F000001_1')


### PR DESCRIPTION
After the python 3 upgrade saving pedigree images does not work (see https://github.com/macarthur-lab/seqr-private/issues/882 and https://github.com/macarthur-lab/seqr/issues/1391#issuecomment-663221914), due to a missed change in opening in 'r' vs 'rb' mode. Our unit test did not use binary for our test images so they couldn't catch this edge case, so I updated the test
