### PR TITLE
Added Google Auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-Django==1.11.29                  # core server-side framework. Behind a major version due to missing Python 2 support
+Django==3.0.8                    # core server-side framework. Behind a major version due to missing Python 2 support
 django-anymail==7.0.0            # for sending emails using cloud-based mail service providers
-django-guardian==1.5.1           # object-level permissions for database records. Behind a major version due to missing Python 2 support
+django-guardian==2.3.0           # object-level permissions for database records. Behind a major version due to missing Python 2 support
+django-allauth==0.42.0           # for Google Auth
 django-hijack==2.1.10            # allows admins to login as other user
-django-cors-headers==3.0.2       # allows CORS requests for client-side development
+django-cors-headers==3.4.0       # allows CORS requests for client-side development
 
 elasticsearch==6.4.0             # elasticsearch client
 elasticsearch-dsl==6.4.0	     # elasticsearch query utilities
@@ -18,4 +19,4 @@ requests-toolbelt==0.9.1         # for troubleshooting requests
 slacker==0.13.0                  # library for sending slack messages
 slugify==0.0.1                   # used for encoding names for guids
 tqdm==4.40.2                     # convenient way to create progress bar for long-running command-line operations
-whitenoise==3.3.0                # simplified static file handling. Behind a major version due to missing Python 2 support
+whitenoise==5.1.0                # simplified static file handling. Behind a major version due to missing Python 2 support

--- a/seqr/models.py
+++ b/seqr/models.py
@@ -278,7 +278,7 @@ class Family(ModelWithGUID):
 
 # TODO should be an ArrayField directly on family once family fields have audit trail (https://github.com/macarthur-lab/seqr-private/issues/449)
 class FamilyAnalysedBy(ModelWithGUID):
-    family = models.ForeignKey(Family)
+    family = models.ForeignKey(Family, on_delete = models.DO_NOTHING)
 
     def __unicode__(self):
         return '{}_{}'.format(self.family.guid, self.created_by)

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -294,6 +294,7 @@ urlpatterns += [
     url(r'^hijack/', include('hijack.urls')),
     url(r'^admin/doc/', include(django.contrib.admindocs.urls)),
     url(r'^admin/', admin.site.urls),
+    url(r'^accounts/', include('allauth.urls')),  # <--
     url(r'^media/(?P<path>.*)$', django.views.static.serve, {
         'document_root': MEDIA_ROOT,
     }),

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -46,6 +46,6 @@ def login_required_error(request):
 
     This is used to redirect AJAX HTTP handlers to the login page.
     """
-    assert not request.user.is_authenticated()
+    assert not request.user.is_authenticated
 
     return create_json_response({}, status=401, reason="login required")

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -75,6 +75,7 @@ COMPOUND_HET_5_JSON = {
 
 class SavedVariantAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project']
+    databases = {'reference_data', 'default'}
 
     def test_saved_variant_data(self):
         url = reverse(saved_variant_data, args=['R0001_1kg'])

--- a/seqr/views/react_app.py
+++ b/seqr/views/react_app.py
@@ -22,7 +22,7 @@ def no_login_main_app(request, *args, **kwargs):
     user_token = kwargs.get('user_token')
     if user_token:
         initial_json['newUser'] = _get_json_for_user(User.objects.get(password=user_token))
-    elif not request.user.is_anonymous():
+    elif not request.user.is_anonymous:
         initial_json['user'] = _get_json_for_user(request.user)
     return _render_app_html(request, initial_json)
 

--- a/settings.py
+++ b/settings.py
@@ -37,6 +37,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
+    'django.contrib.sites',  # <--
+    'allauth',  # <--
+    'allauth.account',  # <--
+    'allauth.socialaccount',  # <--
+    'allauth.socialaccount.providers.google',  # <--
     'hijack',
     'corsheaders',
     'guardian',
@@ -55,6 +60,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'seqr.utils.middleware.JsonErrorMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 # django-hijack plugin
@@ -122,6 +128,7 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',  # required for admin template
             ],
         },
@@ -180,7 +187,22 @@ LOGGING = {
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'guardian.backends.ObjectPermissionBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
 )
+
+SITE_ID = 2
+LOGIN_REDIRECT_URL = '/'
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        }
+    }
+}
 
 # set the secret key
 SECRET_FILE = os.path.join(BASE_DIR, 'django_key')

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,7 +14,6 @@ framework.
 
 """
 import os
-from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
@@ -23,7 +22,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 # setting points here.
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)
 
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication


### PR DESCRIPTION
This PR is only for reviewing an experimental Google Auth for the seqr. It is not going to be merged. The PR makes it easier for comparison, reviewing, and commenting.
In this experiment, the package `django-allauth` is used. Some packages have to be upgraded (see the details in the file `requirements.txt`.

Use the command `python manage.py runserver --nostatic` to run your own seqr. and run command `python manage.py createsuperuser` to create a superuser.

Usages and testing:
1. open `http://localhost:8000/accounts/login` to sign in locally
2. Add `sites`, `Google client ID` and `secret key` in the page of `http://localhost:8000/admin` [See this article](https://medium.com/@whizzoe/in-5-mins-set-up-google-login-to-sign-up-users-on-django-e71d5c38f5d5) for the details of configuration. (Need minimum `staff` level access).
3. Login in with your existing seqr account from `http://localhost:8000/login`, then, open `http://localhost:8000/accounts/social/connections/` to add/remove your Google Auth to your local account
4. open `http://localhost:8000/accounts/logout` to logout.
5. use `http://localhost:8000/accounts/google/login` to sign in with Google Auth.
