### PR TITLE
Fix python in cron

### DIFF
--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -66,10 +66,10 @@ fi
 if [ $ENABLE_DATABASE_BACKUPS ]; then
     # set up cron database backups
     echo 'SHELL=/bin/bash
-0 0 * * * /seqr/manage.py run_settings_backup --bucket $DATABASE_BACKUP_BUCKET --deployment-type $DEPLOYMENT_TYPE >> /var/log/cron.log 2>&1
-0 */4 * * * /seqr/manage.py run_postgres_database_backup --bucket $DATABASE_BACKUP_BUCKET --postgres-host $POSTGRES_SERVICE_HOSTNAME --deployment-type $DEPLOYMENT_TYPE >> /var/log/cron.log 2>&1
-0 0 * * 0 /seqr/manage.py update_omim --omim-key $OMIM_KEY >> /var/log/cron.log 2>&1
-0 0 * * 0 /seqr/manage.py update_human_phenotype_ontology >> /var/log/cron.log 2>&1
+0 0 * * * /usr/local/bin/python /seqr/manage.py run_settings_backup --bucket $DATABASE_BACKUP_BUCKET --deployment-type $DEPLOYMENT_TYPE >> /var/log/cron.log 2>&1
+0 */4 * * * /usr/local/bin/python /seqr/manage.py run_postgres_database_backup --bucket $DATABASE_BACKUP_BUCKET --postgres-host $POSTGRES_SERVICE_HOSTNAME --deployment-type $DEPLOYMENT_TYPE >> /var/log/cron.log 2>&1
+0 0 * * 0 /usr/local/bin/python /seqr/manage.py update_omim --omim-key $OMIM_KEY >> /var/log/cron.log 2>&1
+0 0 * * 0 /usr/local/bin/python /seqr/manage.py update_human_phenotype_ontology >> /var/log/cron.log 2>&1
 ' | crontab -
 
     env > /etc/environment  # this is necessary for crontab commands to run with the right env. vars.


### PR DESCRIPTION
cron by default uses the wrong version of python which causes all our cron jobs to fail. Explicitly setting the desired python executable fixes the issue. I already updated the cron job running in prod to fix our backups so the purpose of this commit is just for future deployments