### PR TITLE
fix reference data update in python 3

### DIFF
--- a/reference_data/management/commands/utils/download_utils.py
+++ b/reference_data/management/commands/utils/download_utils.py
@@ -3,7 +3,6 @@ import os
 import requests
 import tempfile
 from tqdm import tqdm
-import urllib
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +15,7 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
         string: local file path
     """
 
-    if not (url and url.startswith(("http://", "https://", "ftp://"))):
+    if not (url and url.startswith(("http://", "https://"))):
         raise ValueError("Invalid url: {}".format(url))
     local_file_path = os.path.join(to_dir, os.path.basename(url))
     remote_file_size = _get_remote_file_size(url)
@@ -24,12 +23,14 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
         logger.info("Re-using {} previously downloaded from {}".format(local_file_path, url))
         return local_file_path
 
-    input_iter = urllib.urlopen(url)
+    is_gz = url.endswith("gz")
+    response = requests.get(url, stream=is_gz)
+    input_iter = response if is_gz else response.iter_content()
     if verbose:
         logger.info("Downloading {} to {}".format(url, local_file_path))
-        input_iter = tqdm(input_iter, unit=" data" if url.endswith("gz") else " lines")
+        input_iter = tqdm(input_iter, unit=" data" if is_gz else " lines")
 
-    with open(local_file_path, 'w') as f:
+    with open(local_file_path, 'wb') as f:
         f.writelines(input_iter)
 
     input_iter.close()

--- a/reference_data/management/commands/utils/download_utils.py
+++ b/reference_data/management/commands/utils/download_utils.py
@@ -23,7 +23,7 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
         logger.info("Re-using {} previously downloaded from {}".format(local_file_path, url))
         return local_file_path
 
-    is_gz = url.endswith("gz")
+    is_gz = url.endswith(".gz")
     response = requests.get(url, stream=is_gz)
     input_iter = response if is_gz else response.iter_content()
     if verbose:

--- a/reference_data/management/tests/update_mgi_tests.py
+++ b/reference_data/management/tests/update_mgi_tests.py
@@ -1,8 +1,6 @@
 import mock
-
-import os
+import responses
 import tempfile
-import shutil
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -22,49 +20,40 @@ class UpdateMgiTest(TestCase):
     fixtures = ['users', 'reference_data']
     multi_db = True
 
-    def setUp(self):
-        # Create a temporary directory and a test data file
-        self.test_dir = tempfile.mkdtemp()
-        self.temp_file_path = os.path.join(self.test_dir, 'HMD_HumanPhenotype.rpt')
-        with open(self.temp_file_path, 'w') as f:
-            f.write(''.join(MGI_DATA))
-
-    def tearDown(self):
-        # Close the file, the directory will be removed after the test
-        shutil.rmtree(self.test_dir)
-
+    @responses.activate
     @mock.patch('reference_data.management.commands.utils.update_utils.logger')
-    @mock.patch('reference_data.management.commands.utils.update_utils.download_file')
-    def test_update_mgi_command(self, mock_download, mock_logger):
-
-        mock_download.return_value = self.temp_file_path
+    @mock.patch('reference_data.management.commands.utils.download_utils.tempfile')
+    def test_update_mgi_command(self, mock_tempfile, mock_logger):
+        tmp_dir = tempfile.gettempdir()
+        mock_tempfile.gettempdir.return_value = tmp_dir
+        tmp_file = '{}/HMD_HumanPhenotype.rpt'.format(tmp_dir)
 
         # test without a file_path parameter
+        url = 'http://www.informatics.jax.org/downloads/reports/HMD_HumanPhenotype.rpt'
+        responses.add(responses.HEAD, url, headers={"Content-Length": "1024"})
+        responses.add(responses.GET, url, body=''.join(MGI_DATA))
         call_command('update_mgi')
-
-        mock_download.assert_called_with('http://www.informatics.jax.org/downloads/reports/HMD_HumanPhenotype.rpt')
 
         calls = [
             mock.call('Deleting 0 existing MGI records'),
             mock.call('Parsing file'),
             mock.call('Creating 2 MGI records'),
             mock.call('Done'),
-            mock.call('Loaded 2 MGI records from {}. Skipped 2 records with unrecognized genes.'.format(self.temp_file_path)),
+            mock.call('Loaded 2 MGI records from {}. Skipped 2 records with unrecognized genes.'.format(tmp_file)),
             mock.call('Running ./manage.py update_gencode to update the gencode version might fix missing genes')
         ]
         mock_logger.info.assert_has_calls(calls)
 
         # test with a file_path parameter
-        mock_download.reset_mock()
+        responses.remove(responses.GET, url)
         mock_logger.reset_mock()
-        call_command('update_mgi', self.temp_file_path)
-        mock_download.assert_not_called()
+        call_command('update_mgi', tmp_file)
         calls = [
             mock.call('Deleting 2 existing MGI records'),
             mock.call('Parsing file'),
             mock.call('Creating 2 MGI records'),
             mock.call('Done'),
-            mock.call('Loaded 2 MGI records from {}. Skipped 2 records with unrecognized genes.'.format(self.temp_file_path)),
+            mock.call('Loaded 2 MGI records from {}. Skipped 2 records with unrecognized genes.'.format(tmp_file)),
             mock.call('Running ./manage.py update_gencode to update the gencode version might fix missing genes')
         ]
         mock_logger.info.assert_has_calls(calls)


### PR DESCRIPTION
We missed a python 3 update issue in the manage commands for reference_data, because `urllib.urlopen` is not available in python3 but we had it mocked everywhere so we didn't catch it. This PR makes it work in python 3 and also updates all our tests to use the responses library instead of a mocked download so we will catch this sort of error better in the future. 