### PR TITLE
add sv tag types

### DIFF
--- a/seqr/fixtures/new_variant_tag_types.json
+++ b/seqr/fixtures/new_variant_tag_types.json
@@ -3,51 +3,48 @@
     "model": "seqr.varianttagtype",
     "pk": null,
     "fields": {
-        "guid": "VTT_test_segregation",
-        "created_date": "2018-04-27T00:00:00.000Z",
+        "guid": "VTT_validate_sv",
+        "created_date": "2020-08-05T00:00:00.000Z",
         "created_by": null,
         "last_modified_date": null,
         "project": null,
-        "name": "Test segregation",
+        "name": "Validate SV",
         "category": "Collaboration",
         "description": "",
-        "color": "#c17110",
-        "order": 14.6,
-        "is_built_in": true
+        "color": "#4ECDC4",
+        "order": 14.91
     }
 },
 {
     "model": "seqr.varianttagtype",
     "pk": null,
     "fields": {
-        "guid": "VTT_segregation _validated",
-        "created_date": "2018-04-27T00:00:00.000Z",
+        "guid": "VTT_sv_validated",
+        "created_date": "2020-08-05T00:00:00.000Z",
         "created_by": null,
         "last_modified_date": null,
         "project": null,
-        "name": "Segregation validated",
+        "name": "SV validated",
         "category": "Collaboration",
         "description": "",
-        "color": "#799a5b",
-        "order": 14.7,
-        "is_built_in": true
+        "color": "#D4E09B",
+        "order": 14.92
     }
 },
 {
     "model": "seqr.varianttagtype",
     "pk": null,
     "fields": {
-        "guid": "VTT_segregation_did_not_confir",
-        "created_date": "2018-04-27T00:00:00.000Z",
+        "guid": "VTT_sv_did_not_confirm",
+        "created_date": "2020-08-05T00:00:00.000Z",
         "created_by": null,
         "last_modified_date": null,
         "project": null,
-        "name": "Segregation did not confirm",
+        "name": "SV did not confirm",
         "category": "Collaboration",
         "description": "",
-        "color": "#b44b4b",
-        "order": 14.8,
-        "is_built_in": true
+        "color": "#FF6B6B",
+        "order": 14.93
     }
 }
 ]

--- a/seqr/fixtures/variant_tag_types.json
+++ b/seqr/fixtures/variant_tag_types.json
@@ -318,6 +318,53 @@
         "color": "#b44b4b",
         "order": 14.8
     }
+}, {
+    "model": "seqr.varianttagtype",
+    "pk": null,
+    "fields": {
+        "guid": "VTT_validate_sv",
+        "created_date": "2020-08-05T00:00:00.000Z",
+        "created_by": null,
+        "last_modified_date": null,
+        "project": null,
+        "name": "Validate SV",
+        "category": "Collaboration",
+        "description": "",
+        "color": "#4ECDC4",
+        "order": 14.91
+    }
+},
+{
+    "model": "seqr.varianttagtype",
+    "pk": null,
+    "fields": {
+        "guid": "VTT_sv_validated",
+        "created_date": "2020-08-05T00:00:00.000Z",
+        "created_by": null,
+        "last_modified_date": null,
+        "project": null,
+        "name": "SV validated",
+        "category": "Collaboration",
+        "description": "",
+        "color": "#D4E09B",
+        "order": 14.92
+    }
+},
+{
+    "model": "seqr.varianttagtype",
+    "pk": null,
+    "fields": {
+        "guid": "VTT_sv_did_not_confirm",
+        "created_date": "2020-08-05T00:00:00.000Z",
+        "created_by": null,
+        "last_modified_date": null,
+        "project": null,
+        "name": "SV did not confirm",
+        "category": "Collaboration",
+        "description": "",
+        "color": "#FF6B6B",
+        "order": 14.93
+    }
 },
 {
     "model": "seqr.varianttagtype",


### PR DESCRIPTION
Adds tag types as requested in https://github.com/macarthur-lab/seqr-private/issues/894

We add tag type fixture data in 2 places: `variant_tag_types` is the master list of all tag types which is loaded whenever new instances of seqr are set up, and should always include all out core tag types. `new_tag_types` is a transitional list that allows us to add the new types to the existing database by running `./manage.py loaddata new_tag_types`, and once that command has been run its okay to update it to a different set of tags for the next update as we do here