### PR TITLE
Travis test local deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 - coverage report --fail-under=99
 - cd ui/
 - npm test
+- cd ..
 - ./test_local_deployment.sh
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 node_js:
 - '11.8.0'
 
+services:
+- docker
+
 install:
 - ./install_dependencies.sh
 
@@ -14,6 +17,9 @@ script:
 - coverage report --fail-under=99
 - cd ui/
 - npm test
+- docker-compose up -d seqr
+
+
 
 addons:
   postgresql: '9.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ script:
 - coverage report --fail-under=99
 - cd ui/
 - npm test
-- docker-compose up -d seqr
-
-
+- ./test_local_deployment.sh
 
 addons:
   postgresql: '9.6'

--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -47,6 +47,10 @@ cat ~/.pgpass
 # init seqrdb unless it already exists
 if ! psql --host postgres -U postgres -l | grep seqrdb; then
 
+  psql --host postgres -U postgres -c 'CREATE DATABASE reference_data_db';
+  psql --host postgres -U postgres reference_data_db <  <(curl -s $REFERENCE_DATA_DB_INIT_URL | gunzip -c -);
+
+
   psql --host postgres -U postgres -c 'CREATE DATABASE seqrdb';
   python -u manage.py makemigrations
   python -u manage.py migrate
@@ -54,9 +58,6 @@ if ! psql --host postgres -U postgres -l | grep seqrdb; then
   python -u manage.py collectstatic --no-input
   python -u manage.py loaddata variant_tag_types
   python -u manage.py loaddata variant_searches
-
-  psql --host postgres -U postgres -c 'CREATE DATABASE reference_data_db';
-  psql --host postgres -U postgres reference_data_db <  <(curl -s $REFERENCE_DATA_DB_INIT_URL | gunzip -c -);
 
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: gcr.io/seqr-project/postgres:gcloud-prod
     ports:
-      - 5432:5432
+      - 5432:5433
     environment:
       - POSTGRES_PASSWORD=docker-compose-postgres-password
     volumes:
@@ -70,6 +70,7 @@ services:
       - REDIS_SERVICE_HOSTNAME=redis
       - KIBANA_SERVICE_HOSTNAME=kibana
       - PGHOST=postgres
+      - PGPORT=5433
       - PGUSER=postgres
       - GUNICORN_WORKER_THREADS=4
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: gcr.io/seqr-project/postgres:gcloud-prod
     ports:
-      - 5432:5433
+      - 5433:5432
     environment:
       - POSTGRES_PASSWORD=docker-compose-postgres-password
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
   postgres:
     image: gcr.io/seqr-project/postgres:gcloud-prod
     ports:
-      - 5433:5432
+      - 5433:5433
     environment:
+      - PGPORT=5433
       - POSTGRES_PASSWORD=docker-compose-postgres-password
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
@@ -65,6 +66,7 @@ services:
       - PYTHONPATH=/seqr
       - STATIC_MEDIA_DIR=/seqr_static_files
       - POSTGRES_SERVICE_HOSTNAME=postgres
+      - POSTGRES_SERVICE_PORT=5433
       - POSTGRES_PASSWORD=docker-compose-postgres-password
       - ELASTICSEARCH_SERVICE_HOSTNAME=elasticsearch
       - REDIS_SERVICE_HOSTNAME=redis

--- a/test_local_deployment.sh
+++ b/test_local_deployment.sh
@@ -1,0 +1,9 @@
+set -ex
+
+docker-compose up -d seqr
+docker-compose logs postgres
+docker-compose logs elatsicsearch
+docker-compose logs redis
+docker-compose logs seqr
+curl localhost:9200
+docker-compose exec seqr python manage.py createsuperuser --username test --email test@test.com

--- a/test_local_deployment.sh
+++ b/test_local_deployment.sh
@@ -2,8 +2,9 @@ set -ex
 
 docker-compose up -d seqr
 docker-compose logs postgres
-docker-compose logs elatsicsearch
+docker-compose logs elasticsearch
 docker-compose logs redis
-docker-compose logs seqr
 curl localhost:9200
-docker-compose exec seqr python manage.py createsuperuser --username test --email test@test.com
+sleep 30
+docker-compose logs seqr
+echo -ne 'testpassword\n' docker-compose exec seqr python manage.py createsuperuser --username test --email test@test.com

--- a/test_local_deployment.sh
+++ b/test_local_deployment.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -ex
 
 docker-compose up -d seqr


### PR DESCRIPTION
Adding a script which runs `docker-compose up -d seqr` to the end of travis-ci. 
This runs relatively quickly, so I'd vote for keeping it on-commit. 

Changing the postgres port to 5433 within docker-compose was necessary to avoid conflicts with the travis-ci environment
which already has something running on 5432.

Also, there's a change to seqr entrypoint.sh meant to avoid this error:
https://travis-ci.org/github/macarthur-lab/seqr/builds/717251157#L3038
The seqr docker image would need to be rebuilt before the change would take effect. 