### PR TITLE
Added Google Auth supports with native Google client libraries only.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pedigree_images/*
 seqr_settings
 
 django_key
+
+client_secret.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,9 @@ slacker==0.13.0                  # library for sending slack messages
 slugify==0.0.1                   # used for encoding names for guids
 tqdm==4.40.2                     # convenient way to create progress bar for long-running command-line operations
 whitenoise==3.3.0                # simplified static file handling. Behind a major version due to missing Python 2 support
+google-api-core==1.22.0
+google-api-python-client==1.10.0
+google-auth==1.20.1
+google-auth-httplib2==0.0.4
+google-auth-oauthlib==0.4.1
+googleapis-common-protos==1.52.0

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -113,7 +113,7 @@ from seqr.views.apis.staff_api import \
     proxy_to_kibana
 
 from seqr.views.apis.awesomebar_api import awesomebar_autocomplete_handler
-from seqr.views.apis.auth_api import login_required_error, login_view, logout_view
+from seqr.views.apis.auth_api import login_required_error, login_view, logout_view, login_google, login_oauth2callback
 from seqr.views.apis.igv_api import fetch_igv_track
 from seqr.views.apis.analysis_group_api import update_analysis_group_handler, delete_analysis_group_handler
 from seqr.views.apis.project_api import create_project_handler, update_project_handler, delete_project_handler, \
@@ -134,6 +134,7 @@ react_app_pages = [
 no_login_react_app_pages = [
     r'^$',
     'login',
+    'oauth2callback',
     'users/forgot_password',
     'users/set_password/(?P<user_token>.+)',
     'matchmaker/matchbox',
@@ -229,6 +230,8 @@ api_endpoints = {
     'matchmaker/contact_notes/(?P<institution>[^/]+)/update': update_mme_contact_note,
 
     'login': login_view,
+    'login_google': login_google,
+    'login_oauth2callback': login_oauth2callback,
     'users/forgot_password': forgot_password,
     'users/(?P<username>[^/]+)/set_password': set_password,
 

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -107,6 +107,7 @@ def login_oauth2callback(request):
 
     # A temporary solution for Django authenticating the user without a password
     user.backend = 'django.contrib.auth.backends.ModelBackend'
+    request.session['credentials'] = credentials_to_dict(credentials)
     login(request, user)
 
     return create_json_response({'success': True})

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -6,14 +6,20 @@ from django.contrib.auth.models import User
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
 
+import google_auth_oauthlib.flow
+from google.oauth2 import id_token
+from google.auth.transport import requests
+
 import json
 import logging
 
 from seqr.views.utils.json_utils import create_json_response
 
+CLIENT_SECRETS_FILE = "client_secret.json"
 
 logger = logging.getLogger(__name__)
 
+session = {}
 
 @csrf_exempt
 def login_view(request):
@@ -35,6 +41,62 @@ def login_view(request):
 
     return create_json_response({'success': True})
 
+@csrf_exempt
+def login_google(request):
+  # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.
+  flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
+      CLIENT_SECRETS_FILE, scopes=['https://www.googleapis.com/auth/userinfo.profile'])
+
+  # The URI created here must exactly match one of the authorized redirect URIs
+  # for the OAuth 2.0 client, which you configured in the API Console. If this
+  # value doesn't match an authorized URI, you will get a 'redirect_uri_mismatch'
+  # error.
+  flow.redirect_uri = 'http://localhost:3000/oauth2callback'
+
+  authorization_url, state = flow.authorization_url(
+      # Enable offline access so that you can refresh an access token without
+      # re-prompting the user for permission. Recommended for web server apps.
+      access_type='offline',
+      # Enable incremental authorization. Recommended as a best practice.
+      include_granted_scopes='true')
+
+  # Store the state so the callback can verify the auth server response.
+  session['state'] = state
+
+  # Return the url to be sent for the Google Auth server by the the front end
+  return create_json_response({'data': authorization_url})
+
+@csrf_exempt
+def login_oauth2callback(request):
+    # Specify the state when creating the flow in the callback so that it can
+    # verified in the authorization server response.
+    state = session['state']
+
+    flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
+        CLIENT_SECRETS_FILE, scopes = [], state = state)
+    flow.redirect_uri = 'http://localhost:3000/oauth2callback'
+
+    # Use the authorization server's response to fetch the OAuth 2.0 tokens.
+    authorization_response = request.body.decode('utf-8')
+    flow.fetch_token(authorization_response = authorization_response)
+
+    token = flow.credentials.id_token
+
+    try:
+        # Decode the id token (It is a JWT token actually) to get user ID info
+        idinfo = id_token.verify_oauth2_token(token, requests.Request())
+    except ValueError as ve:
+        return create_json_response({}, status=401, reason=str(ve))
+
+    users = User.objects.filter(email__iexact=idinfo['email'])
+    username = users.first().username
+    user = User.objects.get(username=username)
+
+    # A temporary solution for Django authenticating the user without a password
+    user.backend = 'django.contrib.auth.backends.ModelBackend'
+    login(request, user)
+
+    return create_json_response({'success': True})
 
 def logout_view(request):
     logout(request)

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -20,7 +20,6 @@ CLIENT_SECRETS_FILE = "client_secret.json"
 
 logger = logging.getLogger(__name__)
 
-session = {}
 scopes = ['https://www.googleapis.com/auth/userinfo.profile',
           'https://www.googleapis.com/auth/userinfo.email',
           'https://www.googleapis.com/auth/cloud-billing',
@@ -67,7 +66,7 @@ def login_google(request):
       include_granted_scopes='true')
 
   # Store the state so the callback can verify the auth server response.
-  session['state'] = state
+  request.session['state'] = state
 
   # Return the url to be sent for the Google Auth server by the the front end
   return create_json_response({'data': authorization_url})
@@ -76,7 +75,7 @@ def login_google(request):
 def login_oauth2callback(request):
     # Specify the state when creating the flow in the callback so that it can
     # verified in the authorization server response.
-    state = session['state']
+    state = request.session['state']
 
     flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
         CLIENT_SECRETS_FILE, scopes = scopes, state = state)
@@ -86,12 +85,8 @@ def login_oauth2callback(request):
     authorization_response = request.body.decode('utf-8')
     flow.fetch_token(authorization_response = authorization_response)
 
-    session['credentials'] = credentials_to_dict(flow.credentials)
-    credentials = Credentials(**session['credentials'])
-    req_token = requests.Request()
-    credentials.refresh(req_token)
-    access_token = credentials.token
-    print(access_token)
+    credentials = Credentials(**credentials_to_dict(flow.credentials))
+    print(credentials.token)
 
     token = flow.credentials.id_token
 

--- a/settings.py
+++ b/settings.py
@@ -9,9 +9,6 @@ logger = logging.getLogger(__name__)
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1' # for google auth testing only
-os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = '1' #
-
 #########################################################
 #  Django settings
 #########################################################

--- a/settings.py
+++ b/settings.py
@@ -46,6 +46,8 @@ INSTALLED_APPS = [
     'matchmaker',
 ]
 
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,9 @@ logger = logging.getLogger(__name__)
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1' # for google auth testing only
+os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = '1' #
+
 #########################################################
 #  Django settings
 #########################################################

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -15,6 +15,7 @@ import GeneInfoSearch from 'pages/GeneInfoSearch'
 import LocusLists from 'pages/LocusLists'
 import Staff from 'pages/Staff/Staff'
 import Login from 'pages/Login/components/Login'
+import OAuth2Callback from 'pages/Login/components/OAuth2Callback'
 import ForgotPassword from 'pages/Login/components/ForgotPassword'
 import SetPassword from 'pages/Login/components/SetPassword'
 import LandingPage from 'pages/Public/LandingPage'
@@ -57,6 +58,7 @@ ReactDOM.render(
             <Route path="/gene_lists" component={LocusLists} />
             <Route path="/staff" component={Staff} />
             <Route path="/login" component={Login} />
+            <Route path="/oauth2callback" component={OAuth2Callback} />
             <Route path="/users/forgot_password" component={ForgotPassword} />
             <Route path="/users/set_password" component={SetPassword} />
             <Route path="/matchmaker/matchbox" component={MatchmakerInfo} />

--- a/ui/pages/Login/components/Login.jsx
+++ b/ui/pages/Login/components/Login.jsx
@@ -2,7 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
+import { SubmissionError } from 'redux-form'
 
+import { HttpRequestHelper } from 'shared/utils/httpRequestHelper'
 import { validators } from 'shared/components/form/ReduxFormWrapper'
 import { login } from '../reducers'
 import UserFormLayout from './UserFormLayout'
@@ -11,6 +13,19 @@ const FIELDS = [
   { name: 'email', label: 'Email', validate: validators.required },
   { name: 'password', label: 'Password', type: 'password', validate: validators.required },
 ]
+
+
+const googleLogin = () => {
+  return new HttpRequestHelper('/api/login_google',
+    (responseJson) => {
+      // Redirect to google auth website
+      window.location.href = responseJson.data
+    },
+    (e) => {
+      throw new SubmissionError({ _error: [e.message] })
+    },
+  ).get()
+}
 
 const Login = ({ onSubmit }) =>
   <UserFormLayout
@@ -21,6 +36,8 @@ const Login = ({ onSubmit }) =>
     submitButtonText="Log In"
   >
     <Link to="/users/forgot_password">Forgot Password?</Link>
+    <br />
+    <button onClick={googleLogin}>Logging in with Google</button>
   </UserFormLayout>
 
 Login.propTypes = {

--- a/ui/pages/Login/components/OAuth2Callback.jsx
+++ b/ui/pages/Login/components/OAuth2Callback.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { SubmissionError } from 'redux-form'
+import queryString from 'query-string'
+
+import { HttpRequestHelper } from 'shared/utils/httpRequestHelper'
+
+const OAuth2Callback = ({ location }) => {
+  // Send the authentication results to the backend to finish the logging-in procedure
+  new HttpRequestHelper('/api/login_oauth2callback',
+    () => {
+      // Redirect to next page or home page
+      window.location.href = `${window.location.origin}${queryString.parse(window.location.search).next || ''}`
+    },
+    (e) => {
+      throw new SubmissionError({ _error: [e.message] })
+    },
+  ).post(location.pathname + location.search)
+  return <div>Logging in with Google</div>
+}
+
+OAuth2Callback.propTypes = {
+  location: PropTypes.object.isRequired,
+}
+
+export default OAuth2Callback


### PR DESCRIPTION
This PR is an experiment of Google Auth for review only and not intended to be merged.
In this PR, only the native Google libraries are used. The reason for using Google libraries only is to reduce the risk of immaturity of 3rd party packages and have more controls on the Django local user accounts.
We may use the user database remotely on the AnVIL or a Sam server only. This means there is no local user on seqr. In that case, we maybe need to create a temporary user for whom passed the Google authentication. This experiment doesn't cover the temporary user test yet.

Usages:  
- Download Google OAuth2 client secret json to `client_secret.json` under project home directory
- Set environment variables `PYTHONUNBUFFERED=1;DJANGO_SETTINGS_MODULE=settings;OAUTHLIB_INSECURE_TRANSPORT=1;OAUTHLIB_RELAX_TOKEN_SCOPE=1`
- Run seqr backend with command `python manage.py runserver localhost:8000`
- Run seqr frontend with command `npm start` under `ui` sub-directory
- Open `localhost:3000/login` to login
