### PR TITLE
fix file iter content type in python 3

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -30,9 +30,9 @@ def does_file_exist(file_path):
     return os.path.isfile(file_path)
 
 
-def file_iter(file_path, byte_range=None):
+def file_iter(file_path, byte_range=None, raw_content=False):
     if _is_google_bucket_file_path(file_path):
-        for line in _google_bucket_file_iter(file_path, byte_range=byte_range):
+        for line in _google_bucket_file_iter(file_path, byte_range=byte_range, raw_content=raw_content):
             yield line
     else:
         with open(file_path) as f:
@@ -48,10 +48,12 @@ def file_iter(file_path, byte_range=None):
                     yield line
 
 
-def _google_bucket_file_iter(gs_path, byte_range=None):
+def _google_bucket_file_iter(gs_path, byte_range=None, raw_content=False):
     """Iterate over lines in the given file"""
     range_arg = ' -r {}-{}'.format(byte_range[0], byte_range[1]) if byte_range else ''
     process = _run_gsutil_command('cat{}'.format(range_arg), gs_path, gunzip=gs_path.endswith("gz"))
     for line in process.stdout:
+        if not raw_content:
+            line = line.decode('utf-8')
         yield line
 

--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -34,10 +34,10 @@ def _stream_file(request, path):
         last_byte = int(last_byte)
         length = last_byte - first_byte + 1
         resp = StreamingHttpResponse(
-            file_iter(path, byte_range=(first_byte, last_byte)), status=206, content_type=content_type)
+            file_iter(path, byte_range=(first_byte, last_byte), raw_content=True), status=206, content_type=content_type)
         resp['Content-Length'] = str(length)
         resp['Content-Range'] = 'bytes %s-%s' % (first_byte, last_byte)
     else:
-        resp = StreamingHttpResponse(file_iter(path), content_type=content_type)
+        resp = StreamingHttpResponse(file_iter(path, raw_content=True), content_type=content_type)
     resp['Accept-Ranges'] = 'bytes'
     return resp

--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -4,7 +4,7 @@ from django.urls.base import reverse
 from seqr.views.apis.igv_api import fetch_igv_track
 from seqr.views.utils.test_utils import AuthenticationTestCase
 
-STREAMING_READS_CONTENT = ['a', 'b', 'c']
+STREAMING_READS_CONTENT = [b'CRAM\x03\x83', b'\\\t\xfb\xa3\xf7%\x01', b'[\xfc\xc9\t\xae']
 
 
 class IgvAPITest(AuthenticationTestCase):
@@ -18,7 +18,7 @@ class IgvAPITest(AuthenticationTestCase):
         self.check_collaborator_login(url)
         response = self.client.get(url, HTTP_RANGE='bytes=100-200')
         self.assertEqual(response.status_code, 206)
-        self.assertListEqual([val.decode('utf-8') for val in response.streaming_content], STREAMING_READS_CONTENT)
+        self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT)
         mock_subprocess.assert_called_with(
             'gsutil cat -r 100-200 gs://project_A/sample_1.bai',
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
@@ -26,7 +26,7 @@ class IgvAPITest(AuthenticationTestCase):
         url = reverse(fetch_igv_track, args=['R0001_1kg', 'gs://fc-secure-project_A/sample_1.cram.gz'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual([val.decode('utf-8') for val in response.streaming_content], STREAMING_READS_CONTENT)
+        self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT)
         mock_subprocess.assert_called_with(
             'gsutil -u anvil-datastorage cat gs://fc-secure-project_A/sample_1.cram.gz | gunzip -c -q - ',
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
@@ -41,13 +41,13 @@ class IgvAPITest(AuthenticationTestCase):
         self.check_collaborator_login(url)
         response = self.client.get(url, HTTP_RANGE='bytes=100-200')
         self.assertEqual(response.status_code, 206)
-        self.assertListEqual([val.decode('utf-8') for val in response.streaming_content], STREAMING_READS_CONTENT[:2])
+        self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT[:2])
         mock_file.seek.assert_called_with(100)
 
         # test no byte range
         mock_file.reset_mock()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual([val.decode('utf-8') for val in response.streaming_content], STREAMING_READS_CONTENT)
+        self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT)
         mock_file.seek.assert_not_called()
 

--- a/seqr/views/apis/staff_api_tests.py
+++ b/seqr/views/apis/staff_api_tests.py
@@ -423,40 +423,40 @@ EXPECTED_SAMPLE_METADATA_ROW = {
   }
 
 SAMPLE_QC_DATA = [
-    'PCT_CONTAMINATION	AL_PCT_CHIMERAS	HS_PCT_TARGET_BASES_20X	seqr_id	data_type	filter_flags	qc_platform	qc_pop	pop_PC1	pop_PC2	pop_PC3	pop_PC4	pop_PC5	pop_PC6	qc_metrics_filters	sample_qc.call_rate	sample_qc.n_called	sample_qc.n_not_called	sample_qc.n_filtered	sample_qc.n_hom_ref	sample_qc.n_het	sample_qc.n_hom_var	sample_qc.n_non_ref	sample_qc.n_singleton	sample_qc.n_snp	sample_qc.n_insertion	sample_qc.n_deletion	sample_qc.n_transition	sample_qc.n_transversion	sample_qc.n_star	sample_qc.r_ti_tv	sample_qc.r_het_hom_var	sample_qc.r_insertion_deletion	sample_qc.f_inbreeding.f_stat	sample_qc.f_inbreeding.n_called	sample_qc.f_inbreeding.expected_homs	sample_qc.f_inbreeding.observed_homs\n',
-    '1.6E-01	5.567E-01	9.2619E+01	MANZ_1169_DNA	WES	[]	WES-010230 Standard Germline Exome	nfe	6.0654E-02	6.0452E-02	-6.2635E-03	-4.3252E-03	-2.1807E-02	-1.948E-02	["n_snp"]	7.1223E-01	14660344	5923237	0	14485322	114532	60490	175022	585	195114	18516	21882	133675	61439	0	2.1757E+00	1.8934E+00	8.4617E-01	5.3509E-01	14660344	1.4414E+07	14545812\n',
-    'NA	NA	NA	NA	WES	[]	Unknown	nfe	4.6581E-02	5.7881E-02	-5.6011E-03	3.5992E-03	-2.9438E-02	-9.6098E-03	["r_insertion_deletion"]	6.2631E-01	12891805	7691776	0	12743977	97831	49997	147828	237	165267	15474	17084	114154	51113	0	2.2334E+00	1.9567E+00	9.0576E-01	5.4467E-01	12891805	1.2677E+07	12793974\n',
-    'NA	NA	NA	NA19675_1	WES	[]	Unknown	amr	2.2367E-02	-1.9772E-02	6.3769E-02	2.5774E-03	-1.6655E-02	2.0457E-03	["r_ti_tv","n_deletion","n_snp","r_insertion_deletion","n_insertion"]	1.9959E-01	4108373	16475208	0	3998257	67927	42189	110116	18572	127706	13701	10898	82568	45138	0	1.8292E+00	1.6101E+00	1.2572E+00	5.3586E-02	4108373	4.0366E+06	4040446\n',
-    '5.6E-01	3.273E-01	8.1446E+01	NA19678	WES	["coverage"]	Standard Exome Sequencing v4	sas	2.4039E-02	-6.9517E-02	-4.1485E-02	1.421E-01	7.5583E-02	-2.0986E-02	["n_insertion"]	4.6084E-01	9485820	11097761	0	9379951	59871	45998	105869	736	136529	6857	8481	95247	41282	0	2.3072E+00	1.3016E+00	8.0851E-01	5.2126E-01	9485820	9.3608E+06	9425949\n',
-    '5.4E-01	5.0841E+00	8.7288E+01	HG00732	WES	["chimera"]	Standard Germline Exome v5	nfe	5.2785E-02	5.547E-02	-5.82E-03	2.7961E-02	-4.2259E-02	3.0271E-02	["n_insertion","r_insertion_deletion"]	6.8762E-01	14153622	6429959	0	13964844	123884	64894	188778	1719	202194	29507	21971	138470	63724	0	2.173E+00	1.909E+00	1.343E+00	4.924E-01	14153622	1.391E+07	14029738\n',
-    '2.79E+00	1.8996E+01	7.352E+01	HG00733	WES	["contamination","not_real_flag"]	Standard Germline Exome v5	oth	-1.5417E-01	2.8868E-02	-1.3819E-02	4.1915E-02	-4.0001E-02	7.6392E-02	["n_insertion","r_insertion_deletion", "not_real_filter"]	6.1147E-01	12586314	7997267	0	12383958	140784	61572	202356	8751	204812	38051	21065	140282	64530	0	2.1739E+00	2.2865E+00	1.8064E+00	3.6592E-01	12586314	1.2364E+07	12445530\n',
+    b'PCT_CONTAMINATION	AL_PCT_CHIMERAS	HS_PCT_TARGET_BASES_20X	seqr_id	data_type	filter_flags	qc_platform	qc_pop	pop_PC1	pop_PC2	pop_PC3	pop_PC4	pop_PC5	pop_PC6	qc_metrics_filters	sample_qc.call_rate	sample_qc.n_called	sample_qc.n_not_called	sample_qc.n_filtered	sample_qc.n_hom_ref	sample_qc.n_het	sample_qc.n_hom_var	sample_qc.n_non_ref	sample_qc.n_singleton	sample_qc.n_snp	sample_qc.n_insertion	sample_qc.n_deletion	sample_qc.n_transition	sample_qc.n_transversion	sample_qc.n_star	sample_qc.r_ti_tv	sample_qc.r_het_hom_var	sample_qc.r_insertion_deletion	sample_qc.f_inbreeding.f_stat	sample_qc.f_inbreeding.n_called	sample_qc.f_inbreeding.expected_homs	sample_qc.f_inbreeding.observed_homs\n',
+    b'1.6E-01	5.567E-01	9.2619E+01	MANZ_1169_DNA	WES	[]	WES-010230 Standard Germline Exome	nfe	6.0654E-02	6.0452E-02	-6.2635E-03	-4.3252E-03	-2.1807E-02	-1.948E-02	["n_snp"]	7.1223E-01	14660344	5923237	0	14485322	114532	60490	175022	585	195114	18516	21882	133675	61439	0	2.1757E+00	1.8934E+00	8.4617E-01	5.3509E-01	14660344	1.4414E+07	14545812\n',
+    b'NA	NA	NA	NA	WES	[]	Unknown	nfe	4.6581E-02	5.7881E-02	-5.6011E-03	3.5992E-03	-2.9438E-02	-9.6098E-03	["r_insertion_deletion"]	6.2631E-01	12891805	7691776	0	12743977	97831	49997	147828	237	165267	15474	17084	114154	51113	0	2.2334E+00	1.9567E+00	9.0576E-01	5.4467E-01	12891805	1.2677E+07	12793974\n',
+    b'NA	NA	NA	NA19675_1	WES	[]	Unknown	amr	2.2367E-02	-1.9772E-02	6.3769E-02	2.5774E-03	-1.6655E-02	2.0457E-03	["r_ti_tv","n_deletion","n_snp","r_insertion_deletion","n_insertion"]	1.9959E-01	4108373	16475208	0	3998257	67927	42189	110116	18572	127706	13701	10898	82568	45138	0	1.8292E+00	1.6101E+00	1.2572E+00	5.3586E-02	4108373	4.0366E+06	4040446\n',
+    b'5.6E-01	3.273E-01	8.1446E+01	NA19678	WES	["coverage"]	Standard Exome Sequencing v4	sas	2.4039E-02	-6.9517E-02	-4.1485E-02	1.421E-01	7.5583E-02	-2.0986E-02	["n_insertion"]	4.6084E-01	9485820	11097761	0	9379951	59871	45998	105869	736	136529	6857	8481	95247	41282	0	2.3072E+00	1.3016E+00	8.0851E-01	5.2126E-01	9485820	9.3608E+06	9425949\n',
+    b'5.4E-01	5.0841E+00	8.7288E+01	HG00732	WES	["chimera"]	Standard Germline Exome v5	nfe	5.2785E-02	5.547E-02	-5.82E-03	2.7961E-02	-4.2259E-02	3.0271E-02	["n_insertion","r_insertion_deletion"]	6.8762E-01	14153622	6429959	0	13964844	123884	64894	188778	1719	202194	29507	21971	138470	63724	0	2.173E+00	1.909E+00	1.343E+00	4.924E-01	14153622	1.391E+07	14029738\n',
+    b'2.79E+00	1.8996E+01	7.352E+01	HG00733	WES	["contamination","not_real_flag"]	Standard Germline Exome v5	oth	-1.5417E-01	2.8868E-02	-1.3819E-02	4.1915E-02	-4.0001E-02	7.6392E-02	["n_insertion","r_insertion_deletion", "not_real_filter"]	6.1147E-01	12586314	7997267	0	12383958	140784	61572	202356	8751	204812	38051	21065	140282	64530	0	2.1739E+00	2.2865E+00	1.8064E+00	3.6592E-01	12586314	1.2364E+07	12445530\n',
 ]
 
 SAMPLE_QC_DATA_NO_DATA_TYPE = [
-    'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
-    '03133B_2	n/a	[]	Standard Germline Exome v5	nfe	[]\n',
+    b'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
+    b'03133B_2	n/a	[]	Standard Germline Exome v5	nfe	[]\n',
 ]
 
 SAMPLE_QC_DATA_MORE_DATA_TYPE = [
-    'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
-    '03133B_2	WES	[]	Standard Germline Exome v5	nfe	[]\n',
-    '03133B_3	WGS	[]	Standard Germline Exome v5	nfe	[]\n',
+    b'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
+    b'03133B_2	WES	[]	Standard Germline Exome v5	nfe	[]\n',
+    b'03133B_3	WGS	[]	Standard Germline Exome v5	nfe	[]\n',
 ]
 
 
 SAMPLE_QC_DATA_UNEXPECTED_DATA_TYPE = [
-    'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
-    '03133B_2	UNKNOWN	[]	Standard Germline Exome v5	nfe	[]\n',
+    b'seqr_id	data_type	filter_flags	qc_platform	qc_pop	qc_metrics_filters\n',
+    b'03133B_2	UNKNOWN	[]	Standard Germline Exome v5	nfe	[]\n',
 ]
 
 SAMPLE_SV_QC_DATA = [
-    'sample	lt100_raw_calls	lt10_highQS_rare_calls\n',
-    'RP-123_MANZ_1169_DNA_v1_Exome_GCP	FALSE	TRUE\n',
-    'RP-123_NA_v1_Exome_GCP	TRUE	FALSE\n',
-    'RP-123_NA19675_1_v1_Exome_GCP	TRUE	TRUE\n',
-    'RP-123_NA19678_v1_Exome_GCP	TRUE	FALSE\n',
-    'RP-123_HG00732_v1_Exome_GCP	FALSE	TRUE\n',
-    'RP-123_HG00733_v1_Exome_GCP	FALSE	FALSE\n',
+    b'sample	lt100_raw_calls	lt10_highQS_rare_calls\n',
+    b'RP-123_MANZ_1169_DNA_v1_Exome_GCP	FALSE	TRUE\n',
+    b'RP-123_NA_v1_Exome_GCP	TRUE	FALSE\n',
+    b'RP-123_NA19675_1_v1_Exome_GCP	TRUE	TRUE\n',
+    b'RP-123_NA19678_v1_Exome_GCP	TRUE	FALSE\n',
+    b'RP-123_HG00732_v1_Exome_GCP	FALSE	TRUE\n',
+    b'RP-123_HG00733_v1_Exome_GCP	FALSE	FALSE\n',
 ]
 
 
@@ -730,8 +730,8 @@ class StaffAPITest(AuthenticationTestCase):
         expected_variant_guids.add('SV0000002_1248367227_r0390_100')
         self.assertSetEqual(set(response.json()['savedVariantsByGuid'].keys()), expected_variant_guids)
 
-    @mock.patch('seqr.views.apis.staff_api.file_iter')
-    def test_upload_qc_pipeline_output(self, mock_file_iter):
+    @mock.patch('seqr.utils.file_utils.subprocess.Popen')
+    def test_upload_qc_pipeline_output(self, mock_subprocess):
         url = reverse(upload_qc_pipeline_output,)
         self.check_staff_login(url)
 
@@ -740,7 +740,7 @@ class StaffAPITest(AuthenticationTestCase):
         })
 
         # Test missing columns
-        mock_file_iter.return_value = ['', '']
+        mock_subprocess.return_value.stdout = [b'', b'']
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -748,25 +748,25 @@ class StaffAPITest(AuthenticationTestCase):
             'The following required columns are missing: seqr_id, data_type, filter_flags, qc_metrics_filters, qc_pop')
 
         # Test no data type error
-        mock_file_iter.return_value = SAMPLE_QC_DATA_NO_DATA_TYPE
+        mock_subprocess.return_value.stdout = SAMPLE_QC_DATA_NO_DATA_TYPE
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.reason_phrase, 'No data type detected')
 
         # Test multiple data types error
-        mock_file_iter.return_value = SAMPLE_QC_DATA_MORE_DATA_TYPE
+        mock_subprocess.return_value.stdout = SAMPLE_QC_DATA_MORE_DATA_TYPE
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.reason_phrase, 'Multiple data types detected: wes ,wgs')
 
         # Test unexpected data type error
-        mock_file_iter.return_value = SAMPLE_QC_DATA_UNEXPECTED_DATA_TYPE
+        mock_subprocess.return_value.stdout = SAMPLE_QC_DATA_UNEXPECTED_DATA_TYPE
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.reason_phrase, 'Unexpected data type detected: "unknown" (should be "exome" or "genome")')
 
         # Test normal functions
-        mock_file_iter.return_value = SAMPLE_QC_DATA
+        mock_subprocess.return_value.stdout = SAMPLE_QC_DATA
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
@@ -807,8 +807,8 @@ class StaffAPITest(AuthenticationTestCase):
         self.assertDictEqual(indiv.pop_platform_filters, {'n_insertion': '38051', 'r_insertion_deletion': '1.8064E+00'})
         self.assertEqual(indiv.population, 'OTH')
 
-    @mock.patch('seqr.views.apis.staff_api.file_iter')
-    def test_upload_sv_qc(self, mock_file_iter):
+    @mock.patch('seqr.utils.file_utils.subprocess.Popen')
+    def test_upload_sv_qc(self, mock_subprocess):
         url = reverse(upload_qc_pipeline_output, )
         self.check_staff_login(url)
 
@@ -816,7 +816,7 @@ class StaffAPITest(AuthenticationTestCase):
             'file': 'gs://seqr-datasets/v02/GRCh38/RDG_WES_Broad_Internal/v15/sample_qc/sv/sv_sample_metadata.tsv'
         })
 
-        mock_file_iter.return_value = SAMPLE_SV_QC_DATA
+        mock_subprocess.return_value.stdout = SAMPLE_SV_QC_DATA
         response = self.client.post(url, content_type='application/json', data=request_data)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()


### PR DESCRIPTION
For most use cases, reading from a remote file in google we want the content as a string. However, for IGV reads we want raw bytes, so this makes the default behavior as desired and whitelists the use case where we want raw bytes. 
Fixes https://github.com/macarthur-lab/seqr-private/issues/908