### PR TITLE
Fix update saved variants

### DIFF
--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -26,8 +26,9 @@ class ReloadSavedVariantJsonTest(TestCase):
                      PROJECT_NAME,
                      '--family-id={}'.format(FAMILY_ID))
 
+        family_1 = Family.objects.get(id=1)
         mock_get_variants.assert_called_with(
-            set(Family.objects.filter(id=1)), {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C'})
+            [family_1], ['1-1562437-G-C', '1-46859832-G-A','21-3343353-GAGA-G'])
 
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
@@ -44,12 +45,12 @@ class ReloadSavedVariantJsonTest(TestCase):
         call_command('reload_saved_variant_json')
 
         self.assertEqual(mock_get_variants.call_count, 2)
+        family_2 = Family.objects.get(id=2)
         mock_get_variants.assert_has_calls([
             mock.call(
-                set(Family.objects.filter(id__in=[1, 2])),
-                {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C', '12-48367227-TC-T'},
+                [family_1, family_2], ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G'],
             ),
-            mock.call(set(Family.objects.filter(id=11)), {'12-48367227-TC-T', 'prefix_19107_DEL'})
+            mock.call([Family.objects.get(id=11)], ['12-48367227-TC-T', 'prefix_19107_DEL'])
         ], any_order=True)
 
         logger_info_calls = [
@@ -74,8 +75,7 @@ class ReloadSavedVariantJsonTest(TestCase):
                      PROJECT_GUID,
                      '--family-id={}'.format(FAMILY_ID))
 
-        mock_get_variants.assert_called_with(
-            set(Family.objects.filter(id=1)), {'21-3343353-GAGA-G', '1-46859832-G-A', '1-1562437-G-C'})
+        mock_get_variants.assert_called_with([family_1], ['1-1562437-G-C', '1-46859832-G-A', '21-3343353-GAGA-G'])
 
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -3,7 +3,7 @@ import mock
 
 from django.urls.base import reverse
 
-from seqr.models import SavedVariant, VariantNote, VariantTag, VariantFunctionalData
+from seqr.models import SavedVariant, VariantNote, VariantTag, VariantFunctionalData, Family
 from seqr.views.apis.saved_variant_api import saved_variant_data, create_variant_note_handler, create_saved_variant_handler, \
     update_variant_note_handler, delete_variant_note_handler, update_variant_tags_handler, update_saved_variant_json, \
     update_variant_main_transcript, update_variant_functional_data_handler
@@ -707,10 +707,15 @@ class SavedVariantAPITest(AuthenticationTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertSetEqual(
-            set(response.json().keys()),
-            {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100',
-            'SV0059957_11562437_f019313_1', 'SV0059956_11560662_f019313_1'}
+        self.assertDictEqual(
+            response.json(),
+            {'SV0000002_1248367227_r0390_100': None, 'SV0000001_2103343353_r0390_100': None,
+            'SV0059957_11562437_f019313_1': None, 'SV0059956_11560662_f019313_1': None}
+        )
+
+        mock_get_variants.assert_called_with(
+            [Family.objects.get(guid='F000001_1'), Family.objects.get(guid='F000002_2')],
+            ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G']
         )
 
     def test_update_variant_main_transcript(self):

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -25,7 +25,7 @@ def update_project_saved_variant_json(project, family_id=None):
         variant_ids.add(v.variant_id)
         saved_variants_map[(v.variant_id, v.family.guid)] = v
 
-    variants_json = get_es_variants_for_variant_ids(families, variant_ids)
+    variants_json = get_es_variants_for_variant_ids(sorted(families, key=lambda f: f.guid), sorted(variant_ids))
 
     updated_saved_variant_guids = []
     for var in variants_json:


### PR DESCRIPTION
An endpoint was failing because the arguments being passed in to search were sets instead of lists, which caused search to fail