### PR TITLE
Search index updates

### DIFF
--- a/seqr/utils/elasticsearch/constants.py
+++ b/seqr/utils/elasticsearch/constants.py
@@ -269,6 +269,7 @@ PREDICTION_FIELDS_CONFIG = {
     'dbnsfp_Polyphen2_HVAR_pred': {'response_key': 'polyphen'},
     'primate_ai_score': {'response_key': 'primate_ai'},
     'splice_ai_delta_score': {'response_key': 'splice_ai'},
+    'splice_ai_splice_consequence': {'response_key': 'splice_ai_consequence'},
     'dbnsfp_REVEL_score': {},
     'dbnsfp_SIFT_pred': {},
     'StrVCTVRE_score': {'response_key': 'strvctvre'},

--- a/seqr/utils/elasticsearch/constants.py
+++ b/seqr/utils/elasticsearch/constants.py
@@ -242,6 +242,7 @@ NESTED_FIELDS = {
     }.items()
 }
 
+GRCH38_LOCUS_FIELD = 'rg37_locus'
 CORE_FIELDS_CONFIG = {
     'alt': {},
     'contig': {'response_key': 'chrom'},
@@ -255,6 +256,7 @@ CORE_FIELDS_CONFIG = {
     'svType': {},
     'variantId': {},
     'xpos': {'format_value': int},
+    GRCH38_LOCUS_FIELD: {},
 }
 PREDICTION_FIELDS_CONFIG = {
     'cadd_PHRED': {'response_key': 'cadd'},

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -2104,7 +2104,7 @@ class EsUtilsTest(TestCase):
         }
 
         # Test using rg37_locus from pipeline
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, _ = get_es_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 1)
         self.assertListEqual(variants, [expected_grch38_variant])
         mock_liftover.assert_not_called()
@@ -2120,7 +2120,7 @@ class EsUtilsTest(TestCase):
             'liftedOverChrom': None,
             'liftedOverPos': None,
         })
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, _ = get_es_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 1)
         self.assertListEqual(variants, [expected_no_lift_grch38_variant])
         self.assertIsNone(_liftover_grch38_to_grch37())
@@ -2129,7 +2129,7 @@ class EsUtilsTest(TestCase):
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
         mock_liftover.side_effect = None
         mock_liftover.return_value.convert_coordinate.side_effect = lambda chrom, pos: [[chrom, pos - 10]]
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, _ = get_es_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 1)
         self.assertListEqual(variants, [expected_grch38_variant])
         self.assertIsNotNone(_liftover_grch38_to_grch37())

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -550,6 +550,7 @@ MAPPING_FIELDS = [
     'dbnsfp_REVEL_score',
     'dbnsfp_GERP_RS',
     'splice_ai_delta_score',
+    'splice_ai_splice_consequence',
     'dbnsfp_FATHMM_pred',
     'primate_ai_score',
     'dbnsfp_SIFT_pred',

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -600,6 +600,7 @@ MAPPING_FIELDS = [
     'topmed_AF',
     'topmed_AN',
     'gnomad_genomes_FAF_AF',
+    'rg37_locus',
 ]
 SV_MAPPING_FIELDS = [
     'start',

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -414,7 +414,8 @@ PARSED_VARIANTS = [
         'pos': 248367227,
         'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
                         'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
-                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None},
+                        'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
+                        'splice_ai_consequence': None},
         'ref': 'TC',
         'rsid': None,
         'transcripts': {
@@ -472,7 +473,7 @@ PARSED_VARIANTS = [
         'predictions': {
             'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None, 'polyphen': None,
             'dann': None, 'sift': None, 'cadd': None, 'metasvm': None, 'primate_ai': 1, 'gerp_rs': None,
-            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
+            'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None, 'splice_ai_consequence': None,
         },
         'ref': 'GAGA',
         'rsid': None,
@@ -523,7 +524,8 @@ PARSED_SV_VARIANT = {
     'pos': 49045487,
     'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
                     'polyphen': None, 'dann': None, 'sift': None, 'cadd': None, 'metasvm': None, 'primate_ai': None,
-                    'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': 0.374},
+                    'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': 0.374,
+                    'splice_ai_consequence': None},
     'ref': None,
     'rsid': None,
     'transcripts': {

--- a/ui/shared/components/panel/variants/Predictions.jsx
+++ b/ui/shared/components/panel/variants/Predictions.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
-import { Icon, Transition } from 'semantic-ui-react'
+import { Icon, Transition, Popup } from 'semantic-ui-react'
 
 import { getGenesById } from 'redux/selectors'
 import { PREDICTION_INDICATOR_MAP, POLYPHEN_MAP, MUTTASTER_MAP, getVariantMainGeneId } from 'shared/utils/constants'
@@ -20,34 +20,48 @@ const PredictionValue = styled.span`
 const NUM_TO_SHOW_ABOVE_THE_FOLD = 6 // how many predictors to show immediately
 
 
-const predictionFieldValue = (predictions, { field, dangerThreshold, warningThreshold, indicatorMap, noSeverity }) => {
+const predictionFieldValue = (predictions, { field, dangerThreshold, warningThreshold, indicatorMap, noSeverity, infoField, infoTitle }) => {
   let value = predictions[field]
   if (noSeverity || value === null || value === undefined) {
     return { value }
   }
 
+  const infoValue = predictions[infoField]
+
   if (dangerThreshold) {
     value = parseFloat(value).toPrecision(2)
+    let color = 'green'
     if (value >= dangerThreshold) {
-      return { value, color: 'red' }
+      color = 'red'
     } else if (value >= warningThreshold) {
-      return { value, color: 'yellow' }
+      color = 'yellow'
     }
-    return { value, color: 'green' }
+    return { value, color, infoValue, infoTitle }
   }
 
   return indicatorMap ? { ...PREDICTION_INDICATOR_MAP[value[0]], ...indicatorMap[value[0]] } : PREDICTION_INDICATOR_MAP[value[0]]
 }
 
-const Prediction = ({ field, value, color }) =>
-  <div>
-    <Icon name="circle" size="small" color={color} /> {snakecaseToTitlecase(field)}
-    <PredictionValue> {value}</PredictionValue>
-  </div>
+const Prediction = ({ field, value, color, infoValue, infoTitle }) => {
+  const indicator = infoValue ? <Popup
+    header={infoTitle}
+    content={infoValue}
+    trigger={<Icon name="question circle" size="small" color={color} />}
+  /> : <Icon name="circle" size="small" color={color} />
+  return (
+    <div>
+      {indicator} {snakecaseToTitlecase(field)}
+      <PredictionValue> {value}</PredictionValue>
+    </div>
+  )
+}
+
 
 Prediction.propTypes = {
   field: PropTypes.string.isRequired,
   value: PropTypes.any.isRequired,
+  infoValue: PropTypes.any,
+  infoTitle: PropTypes.string,
   color: PropTypes.string,
 }
 
@@ -56,7 +70,7 @@ const PREDICTOR_FIELDS = [
   { field: 'revel', warningThreshold: 0.5, dangerThreshold: 0.75 },
   { field: 'primate_ai', warningThreshold: 0.5, dangerThreshold: 0.7 },
   { field: 'mpc', warningThreshold: 1, dangerThreshold: 2 },
-  { field: 'splice_ai', warningThreshold: 0.5, dangerThreshold: 0.8 },
+  { field: 'splice_ai', warningThreshold: 0.5, dangerThreshold: 0.8, infoField: 'splice_ai_consequence', infoTitle: 'Predicted Consequence' },
   { field: 'eigen', warningThreshold: 1, dangerThreshold: 2 },
   { field: 'dann', warningThreshold: 0.93, dangerThreshold: 0.96 },
   { field: 'strvctvre', warningThreshold: 0.5, dangerThreshold: 0.75 },


### PR DESCRIPTION
The PR allows seqr to use 2 new fields that were recently added to the elasticsearch pipeline: 

- `splice_ai_splice_consequence`  is now shown as a hover-over for the splice ai prediction if present
- `rg37_locus` includes the lifted under coordinates fro grch38 variants. We were getting this value by doing the lift using python on every variant when results were returned, which is still supported for indices without this new field.  There are some inconsistencies between how the pipeline does lifting and how the python library does so its best to use the pipeline when possible (see https://github.com/macarthur-lab/seqr-private/issues/852). Also, the python lifting can be slow, so this should give us a search performance boost. 