### PR TITLE
Fix predictor sort

### DIFF
--- a/seqr/management/commands/reset_cached_search_results.py
+++ b/seqr/management/commands/reset_cached_search_results.py
@@ -11,12 +11,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--project', help='optional project to reload variants for')
+        parser.add_argument('--reset-index-metadata', action='store_true', help='reset the index metadata')
 
     def handle(self, *args, **options):
         """transfer project"""
         project_name = options['project']
         project = Project.objects.get(name=project_name) if project_name else None
-        reset_cached_search_results(project=project)
+        reset_cached_search_results(project=project, reset_index_metadata=options.get('reset_index_metadata'))
         logger.info(u'Reset cached search results for {}'.format(project_name or 'all projects'))
 
 

--- a/seqr/management/tests/reset_cached_search_results_tests.py
+++ b/seqr/management/tests/reset_cached_search_results_tests.py
@@ -45,6 +45,13 @@ class ResetCachedSearchResultsTest(TestCase):
         mock_utils_logger.info.assert_called_with('Reset 1 cached results')
         mock_command_logger.info.assert_called_with('Reset cached search results for all projects')
 
+        # Test command for reset metadata
+        mock_redis.reset_mock()
+        call_command('reset_cached_search_results', '--reset-index-metadata')
+        mock_redis.return_value.delete.assert_called_with('search_results__*', 'index_metadata__*')
+        mock_utils_logger.info.assert_called_with('Reset 2 cached results')
+        mock_command_logger.info.assert_called_with('Reset cached search results for all projects')
+
         # Test with connection error
         mock_redis.side_effect = Exception('invalid redis')
         call_command('reset_cached_search_results')

--- a/seqr/utils/elasticsearch/constants.py
+++ b/seqr/utils/elasticsearch/constants.py
@@ -188,12 +188,6 @@ SORT_FIELDS = {
             }
         }
     }],
-    'cadd': [{'cadd_PHRED': {'order': 'desc', 'unmapped_type': 'float'}}],
-    'revel': [{'dbnsfp_REVEL_score': {'order': 'desc', 'unmapped_type': 'float'}}],
-    'eigen': [{'eigen_Eigen_phred': {'order': 'desc', 'unmapped_type': 'float'}}],
-    'mpc': [{'mpc_MPC': {'order': 'desc', 'unmapped_type': 'float'}}],
-    'splice_ai': [{'splice_ai_delta_score': {'order': 'desc', 'unmapped_type': 'float'}}],
-    'primate_ai': [{'primate_ai_score': {'order': 'desc', 'unmapped_type': 'float'}}],
     'constraint': [{
         '_script': {
             'order': 'asc',
@@ -229,6 +223,18 @@ POPULATION_SORTS = {
         }
     }] for sort, pop_key in {'gnomad': 'gnomad_genomes', 'exac': 'exac', '1kg': 'g1k'}.items()}
 SORT_FIELDS.update(POPULATION_SORTS)
+PREDICTOR_SORT_FIELDS = {
+    'cadd': 'cadd_PHRED',
+    'revel': 'dbnsfp_REVEL_score',
+    'eigen': 'eigen_Eigen_phred',
+    'mpc': 'mpc_MPC',
+    'splice_ai': 'splice_ai_delta_score',
+    'primate_ai': 'primate_ai_score',
+}
+SORT_FIELDS.update({
+    sort: [{sort_field: {'order': 'desc', 'unmapped_type': True}}]
+    for sort, sort_field in PREDICTOR_SORT_FIELDS.items()
+})
 
 CLINVAR_FIELDS = ['clinical_significance', 'variation_id', 'allele_id', 'gold_stars']
 HGMD_FIELDS = ['accession', 'class']

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -1284,7 +1284,7 @@ def _parse_es_sort(sort, sort_config):
         # ES returns these values for sort when a sort field is missing, using the correct value for the given direction
         sort = maxsize
     elif hasattr(sort_config, 'values') and any(cfg.get('order') == 'desc' for cfg in sort_config.values()):
-        sort = sort * -1
+        sort = float(sort) * -1
 
     return sort
 

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -30,7 +30,7 @@ ES_VARIANTS = [
           'hgmd_accession': None,
           'g1k_AF': None,
           'gnomad_genomes_Hom': 0,
-          'cadd_PHRED': 25.9,
+          'cadd_PHRED': '25.9',
           'exac_AC_Hemi': None,
           'g1k_AC': None,
           'topmed_AN': 125568,
@@ -639,18 +639,23 @@ SOURCE_FIELDS.update(MAPPING_FIELDS)
 SOURCE_FIELDS.update(SV_MAPPING_FIELDS)
 SOURCE_FIELDS -= {'samples_no_call', 'samples_cn_0', 'samples_cn_1', 'samples_cn_2', 'samples_cn_3', 'samples_cn_gte_4'}
 
+FIELD_TYPE_MAP = {
+    'cadd_PHRED': 'keyword',
+    'primate_ai_score': 'double',
+}
+
 INDEX_METADATA = {
     INDEX_NAME: {'variant': {
         '_meta': {'genomeVersion': '37'},
-        'properties': {field: {} for field in MAPPING_FIELDS},
+        'properties': {field: {'type': FIELD_TYPE_MAP.get(field, 'keyword')} for field in MAPPING_FIELDS},
     }},
     SECOND_INDEX_NAME: {'variant': {
         '_meta': {'genomeVersion': '38', 'datasetType': 'VARIANTS'},
-        'properties': {field: {} for field in MAPPING_FIELDS},
+        'properties': {field: {'type': FIELD_TYPE_MAP.get(field, 'keyword')} for field in MAPPING_FIELDS},
     }},
     SV_INDEX_NAME: {'structural_variant': {
         '_meta': {'genomeVersion': '37', 'datasetType': 'SV'},
-        'properties': {field: {} for field in SV_MAPPING_FIELDS},
+        'properties': {field: {'type': FIELD_TYPE_MAP.get(field, 'keyword')} for field in SV_MAPPING_FIELDS},
     }},
 }
 INDEX_METADATA[NO_LIFT_38_INDEX_NAME] = INDEX_METADATA[SECOND_INDEX_NAME]
@@ -1383,7 +1388,7 @@ class EsUtilsTest(TestCase):
                     }},
                 ]
             }}
-        ], sort=[{'cadd_PHRED': {'order': 'desc', 'unmapped_type': 'float'}}, 'xpos'])
+        ], sort=[{'cadd_PHRED': {'order': 'desc', 'unmapped_type': 'keyword'}}, 'xpos'])
 
     def test_sv_get_es_variants(self):
         search_model = VariantSearch.objects.create(search={
@@ -2423,7 +2428,7 @@ class EsUtilsTest(TestCase):
 
         variants, _ = get_es_variants(results_model, sort='primate_ai', num_results=2)
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY], sort=[
-            {'primate_ai_score': {'order': 'desc', 'unmapped_type': 'float'}}, 'xpos'])
+            {'primate_ai_score': {'order': 'desc', 'unmapped_type': 'double'}}, 'xpos'])
         self.assertEqual(variants[0]['_sort'][0], maxsize)
         self.assertEqual(variants[1]['_sort'][0], -1)
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -413,7 +413,7 @@ PARSED_VARIANTS = [
         },
         'pos': 248367227,
         'predictions': {'splice_ai': None, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': None,
-                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': 25.9, 'metasvm': None, 'primate_ai': None,
+                        'polyphen': None, 'dann': None, 'sift': None, 'cadd': '25.9', 'metasvm': None, 'primate_ai': None,
                         'gerp_rs': None, 'mpc': None, 'phastcons_100_vert': None, 'strvctvre': None,
                         'splice_ai_consequence': None},
         'ref': 'TC',

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -38,7 +38,7 @@ def update_project_saved_variant_json(project, family_id=None):
     return updated_saved_variant_guids
 
 
-def reset_cached_search_results(project):
+def reset_cached_search_results(project, reset_index_metadata=False):
     try:
         redis_client = redis.StrictRedis(host=REDIS_SERVICE_HOSTNAME, socket_connect_timeout=3)
         keys_to_delete = []
@@ -48,6 +48,8 @@ def reset_cached_search_results(project):
                 keys_to_delete += redis_client.keys(pattern='search_results__{}*'.format(guid))
         else:
             keys_to_delete = redis_client.keys(pattern='search_results__*')
+        if reset_index_metadata:
+            keys_to_delete = redis_client.keys(pattern='index_metadata__*')
         if keys_to_delete:
             redis_client.delete(*keys_to_delete)
             logger.info('Reset {} cached results'.format(len(keys_to_delete)))

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -49,7 +49,7 @@ def reset_cached_search_results(project, reset_index_metadata=False):
         else:
             keys_to_delete = redis_client.keys(pattern='search_results__*')
         if reset_index_metadata:
-            keys_to_delete = redis_client.keys(pattern='index_metadata__*')
+            keys_to_delete += redis_client.keys(pattern='index_metadata__*')
         if keys_to_delete:
             redis_client.delete(*keys_to_delete)
             logger.info('Reset {} cached results'.format(len(keys_to_delete)))


### PR DESCRIPTION
Fixes https://github.com/macarthur-lab/seqr-private/issues/912

`unmapped_type` is only used by elasticsearch if there is an index that is entirely missing a field thats is sorted on. When searching across variants and SVs this is used because SVs don't have any of the predictors. However, it turns out that not all regular variant indices use the same data type for field values, so while on the index used for testing this functionality when it was first implemented everything was a `float`, across all indices there are `float`, `half_float`, `double, and `keyword`. This updates the code to dynamically use the correct type for the given index and field