### PR TITLE
Es test update

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ django-debug-toolbar==1.11                      # https://github.com/jazzband/dj
 django-debug-toolbar-request-history==0.0.11    # for debugging database queries on async requests.
 mock                                            # mock objects for unit tests
 responses==0.10.15                               # mock HTTP responses for unit tests
+urllib3-mock==0.3.3                             # mock urllib3 for tests
 Jinja2==2.10.1                                  # jinja templates are used by servctl k8s deployment scripts

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -14,8 +14,6 @@ from seqr.views.utils.test_utils import AuthenticationTestCase, urllib3_response
 PROJECT_GUID = 'R0001_1kg'
 INDEX_NAME = 'test_index'
 SV_INDEX_NAME = 'test_new_sv_index'
-EMPTY_INDEX_NAME = 'test_empty_index'
-INVALID_SAMPLE_INDEX_NAME = 'test_invalid_index'
 ADD_DATASET_PAYLOAD = json.dumps({'elasticsearchIndex': INDEX_NAME, 'datasetType': 'VARIANTS'})
 
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -68,7 +68,7 @@ class DatasetAPITest(AuthenticationTestCase):
 
         self.assertEqual(len(urllib3_responses.calls), 2)
         self.assertDictEqual(
-            urllib3_responses.call_request_json(index=1),
+            urllib3_responses.call_request_json(),
             {'aggs': {'sample_ids': {'terms': {'field': 'samples_num_alt_1', 'size': 10000}}}}
         )
 
@@ -228,7 +228,7 @@ class DatasetAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(
-            urllib3_responses.call_request_json(index=-1),
+            urllib3_responses.call_request_json(),
             {'aggs': {'sample_ids': {'terms': {'field': 'samples', 'size': 10000}}}}
         )
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -4,28 +4,29 @@ import subprocess
 from datetime import datetime
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls.base import reverse
-
 from io import StringIO
 
 from seqr.models import Sample
 from seqr.views.apis.dataset_api import add_variants_dataset_handler, receive_igv_table_handler, update_individual_igv_sample
-from seqr.views.utils.test_utils import AuthenticationTestCase
+from seqr.views.utils.test_utils import AuthenticationTestCase, urllib3_responses
 
 
 PROJECT_GUID = 'R0001_1kg'
 INDEX_NAME = 'test_index'
 SV_INDEX_NAME = 'test_new_sv_index'
+EMPTY_INDEX_NAME = 'test_empty_index'
+INVALID_SAMPLE_INDEX_NAME = 'test_invalid_index'
 ADD_DATASET_PAYLOAD = json.dumps({'elasticsearchIndex': INDEX_NAME, 'datasetType': 'VARIANTS'})
 
 
 class DatasetAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project']
 
+    @mock.patch('seqr.utils.redis_utils.redis.StrictRedis', mock.MagicMock())
     @mock.patch('seqr.views.utils.dataset_utils.random.randint')
     @mock.patch('seqr.views.utils.dataset_utils.file_iter')
-    @mock.patch('seqr.views.utils.dataset_utils.get_index_metadata')
-    @mock.patch('seqr.views.utils.dataset_utils.elasticsearch_dsl.Search')
-    def test_add_variants_dataset(self, mock_es_search, mock_get_index_metadata, mock_file_iter, mock_random):
+    @urllib3_responses.activate
+    def test_add_variants_dataset(self, mock_file_iter, mock_random):
         url = reverse(add_variants_dataset_handler, args=[PROJECT_GUID])
         self.check_manager_login(url)
 
@@ -45,7 +46,10 @@ class DatasetAPITest(AuthenticationTestCase):
         self.assertEqual(Sample.objects.filter(sample_id='NA19678_1').count(), 0)
 
         mock_random.return_value = 98765432101234567890
-        mock_es_search.return_value.params.return_value.execute.return_value.aggregations.sample_ids.buckets = []
+
+        urllib3_responses.add_json('/{}/_mapping'.format(INDEX_NAME), {INDEX_NAME: {'mappings': {}}})
+        urllib3_responses.add_json(
+            '/{}/_search?size=0'.format(INDEX_NAME), {'aggregations': {'sample_ids': {'buckets': []}}})
 
         # Send invalid requests
         response = self.client.post(url, content_type='application/json', data=json.dumps({}))
@@ -62,56 +66,66 @@ class DatasetAPITest(AuthenticationTestCase):
         self.assertDictEqual(response.json(), {
             'errors': ['No samples found in the index. Make sure the specified caller type is correct']})
 
-        mock_es_search.return_value.params.return_value.execute.return_value.aggregations.sample_ids.buckets = [
-            {'key': 'NA19679'}, {'key': 'NA19678_1'},
-        ]
-        mock_get_index_metadata.return_value = {}
+        self.assertEqual(len(urllib3_responses.calls), 2)
+        self.assertDictEqual(
+            urllib3_responses.call_request_json(index=1),
+            {'aggs': {'sample_ids': {'terms': {'field': 'samples_num_alt_1', 'size': 10000}}}}
+        )
+
+        urllib3_responses.replace_json(
+            '/{}/_search?size=0'.format(INDEX_NAME),
+            {'aggregations': {'sample_ids': {'buckets': [{'key': 'NA19679'}, {'key': 'NA19678_1'}]}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Index metadata must contain fields: genomeVersion, sampleType, sourceFilePath']})
 
-        mock_get_index_metadata.return_value = {INDEX_NAME: {
-            'sampleType': 'NOT_A_TYPE',
-            'genomeVersion': '37',
-            'sourceFilePath': 'invalidpath.txt',
-        }}
+        urllib3_responses.replace_json('/{}/_mapping'.format(INDEX_NAME), {
+            INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'NOT_A_TYPE',
+                'genomeVersion': '37',
+                'sourceFilePath': 'invalidpath.txt',
+            }}}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Sample type not supported: NOT_A_TYPE']})
 
-        mock_get_index_metadata.return_value = {INDEX_NAME: {
-            'sampleType': 'WES',
-            'genomeVersion': '38',
-            'sourceFilePath': 'invalidpath.txt',
-        }}
+        urllib3_responses.replace_json('/{}/_mapping'.format(INDEX_NAME), {
+            INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'WES',
+                'genomeVersion': '38',
+                'sourceFilePath': 'invalidpath.txt',
+            }}}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Index "test_index" has genome version 38 but this project uses version 37']})
 
-        mock_get_index_metadata.return_value = {INDEX_NAME: {
-            'sampleType': 'WES',
-            'genomeVersion': '37',
-            'sourceFilePath': 'invalidpath.txt',
-        }}
+        urllib3_responses.replace_json('/{}/_mapping'.format(INDEX_NAME), {
+            INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'WES',
+                'genomeVersion': '37',
+                'sourceFilePath': 'invalidpath.txt',
+            }}}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Variant call dataset path must end with .vcf.gz or .vds or .bed']})
 
-        mock_get_index_metadata.return_value = {INDEX_NAME: {
-            'sampleType': 'WES',
-            'genomeVersion': '37',
-            'sourceFilePath': 'test_data.vds',
-            'datasetType': 'SV',
-        }}
+        urllib3_responses.replace_json('/{}/_mapping'.format(INDEX_NAME), {
+            INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'WES',
+                'genomeVersion': '37',
+                'sourceFilePath': 'test_data.vds',
+                'datasetType': 'SV',
+            }}}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Index "test_index" has dataset type SV but expects VARIANTS']})
 
-        mock_get_index_metadata.return_value = {INDEX_NAME: {
-            'sampleType': 'WES',
-            'genomeVersion': '37',
-            'sourceFilePath': 'test_data.vds',
-        }}
+        urllib3_responses.replace_json('/{}/_mapping'.format(INDEX_NAME), {
+            INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'WES',
+                'genomeVersion': '37',
+                'sourceFilePath': 'test_data.vds',
+            }}}}})
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Matches not found for ES sample ids: NA19678_1. Uploading a mapping file for these samples, or select the "Ignore extra samples in callset" checkbox to ignore.']})
@@ -124,9 +138,9 @@ class DatasetAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['The following families are included in the callset but are missing some family members: 1 (NA19675_1, NA19678).']})
 
-        mock_es_search.return_value.params.return_value.execute.return_value.aggregations.sample_ids.buckets = [
-            {'key': 'NA19673'}
-        ]
+        urllib3_responses.replace_json(
+            '/{}/_search?size=0'.format(INDEX_NAME),
+            {'aggregations': {'sample_ids': {'buckets': [{'key': 'NA19673'}]}}})
         response = self.client.post(url, content_type='application/json', data=json.dumps({
             'elasticsearchIndex': INDEX_NAME,
             'datasetType': 'VARIANTS',
@@ -146,9 +160,8 @@ class DatasetAPITest(AuthenticationTestCase):
         self.assertDictEqual(response.json(), {'errors': ['Must contain 2 columns: NA19678_1, NA19678, metadata']})
 
         # Send valid request
-        mock_es_search.return_value.params.return_value.execute.return_value.aggregations.sample_ids.buckets = [
-            {'key': 'NA19675'}, {'key': 'NA19679'}, {'key': 'NA19678_1'},
-        ]
+        urllib3_responses.replace_json('/{}/_search?size=0'.format(INDEX_NAME), {'aggregations': {
+            'sample_ids': {'buckets': [{'key': 'NA19675'}, {'key': 'NA19679'}, {'key': 'NA19678_1'}]}}})
         mock_file_iter.return_value = StringIO('NA19678_1,NA19678\n')
         response = self.client.post(url, content_type='application/json', data=json.dumps({
             'elasticsearchIndex': INDEX_NAME,
@@ -198,20 +211,26 @@ class DatasetAPITest(AuthenticationTestCase):
 
         # Adding an SV index works additively with the regular variants index
         mock_random.return_value = 1234567
-        mock_es_search.return_value.params.return_value.execute.return_value.aggregations.sample_ids.buckets = [
-            {'key': 'NA19675_1'}
-        ]
-        mock_get_index_metadata.return_value = {SV_INDEX_NAME: {
-            'sampleType': 'WES',
-            'genomeVersion': '37',
-            'sourceFilePath': 'test_data.bed',
-            'datasetType': 'SV',
-        }}
+        urllib3_responses.add_json('/{}/_mapping'.format(SV_INDEX_NAME), {
+            SV_INDEX_NAME: {'mappings': {'variant': {'_meta': {
+                'sampleType': 'WES',
+                'genomeVersion': '37',
+                'sourceFilePath': 'test_data.bed',
+                'datasetType': 'SV',
+            }}}}})
+        urllib3_responses.add_json(
+            '/{}/_search?size=0'.format(SV_INDEX_NAME),
+            {'aggregations': {'sample_ids': {'buckets': [{'key': 'NA19675_1'}]}}})
         response = self.client.post(url, content_type='application/json', data=json.dumps({
             'elasticsearchIndex': SV_INDEX_NAME,
             'datasetType': 'SV',
         }))
         self.assertEqual(response.status_code, 200)
+
+        self.assertDictEqual(
+            urllib3_responses.call_request_json(index=-1),
+            {'aggs': {'sample_ids': {'terms': {'field': 'samples', 'size': 10000}}}}
+        )
 
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'samplesByGuid', 'individualsByGuid', 'familiesByGuid'})

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import User, Group
 from django.test import TestCase
 from guardian.shortcuts import assign_perm
 import json
+from urllib3_mock import Responses
+
 from seqr.models import Project, CAN_VIEW, CAN_EDIT
 
 
@@ -88,6 +90,27 @@ class AuthenticationTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
 
         self.login_staff_user()
+
+# The responses library for mocking requests does not work with urllib3 (which is used by elasticsearch)
+# The urllib3_mock library works for those requests, but it has limited functionality, so this extension adds helper
+# methods for easier usage
+class Urllib3Responses(Responses):
+    def add_json(self, url, json_response, method=None, match_querystring=True, **kwargs):
+        if not method:
+            method = self.GET
+        body = json.dumps(json_response)
+        self.add(method, url, match_querystring=match_querystring, content_type='application/json', body=body, **kwargs)
+
+    def replace_json(self, url, *args, **kwargs):
+        existing_index = next(i for i, match in enumerate(self._urls) if match['url'] == url)
+        self.add_json(url, *args, **kwargs)
+        self._urls[existing_index] = self._urls.pop()
+
+    def call_request_json(self, index=0):
+        return json.loads(self.calls[index].request.body)
+
+
+urllib3_responses = Urllib3Responses()
 
 
 USER_FIELDS = {'dateJoined', 'email', 'firstName', 'isStaff', 'lastLogin', 'lastName', 'username', 'displayName', 'id'}

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -106,7 +106,7 @@ class Urllib3Responses(Responses):
         self.add_json(url, *args, **kwargs)
         self._urls[existing_index] = self._urls.pop()
 
-    def call_request_json(self, index=0):
+    def call_request_json(self, index=-1):
         return json.loads(self.calls[index].request.body)
 
 


### PR DESCRIPTION
Our tests for elasticsearch currently mock out the python elasticsearch client library. As part of upgrading ES we will be upgrading the client library as well. Since we mock it out everywhere it is used, if there are change to how the library behaves our test won;t'catch them. Therefore, I'm updating our unit tests to instead mock out the actual requests to elasticsearch, and I let the client library generate and parse those requests in the test just as it does in real life. 

Note that the `responses` library we use in most of our tests for mocking out http requests does not work for requests created in python by the `urllib3` library which is what is generated by elasticsearch, so I added the `urllib3-mock` library to test those requests 