### PR TITLE
fix loading context for searches

### DIFF
--- a/ui/pages/Search/components/VariantSearchResults.jsx
+++ b/ui/pages/Search/components/VariantSearchResults.jsx
@@ -8,7 +8,7 @@ import { InlineToggle } from 'shared/components/form/Inputs'
 import ReduxFormWrapper from 'shared/components/form/ReduxFormWrapper'
 import VariantSearchResults, { DisplayVariants } from 'shared/components/panel/search/VariantSearchResults'
 
-import { updateCompoundHetDisplay, loadSingleSearchedVariant } from '../reducers'
+import { updateCompoundHetDisplay, loadSingleSearchedVariant, loadProjectFamiliesContext } from '../reducers'
 import { getFlattenCompoundHet, getSearchContextIsLoading, getInhertanceFilterMode } from '../selectors'
 import { ALL_RECESSIVE_INHERITANCE_FILTERS } from '../constants'
 
@@ -19,7 +19,7 @@ const COMPOUND_HET_TOGGLE_FIELDS = [{
   labelHelp: 'Display individual variants instead of pairs for compound heterozygous mutations.',
 }]
 
-const BaseVariantSearchResults = React.memo(({ inheritanceFilter, toggleUnpair, flattenCompoundHet, match, ...props }) => {
+const BaseVariantSearchResults = React.memo(({ inheritanceFilter, toggleUnpair, flattenCompoundHet, match, initialLoad, ...props }) => {
   const resultProps = {
     loadVariants: loadSearchedVariants,
     flattenCompoundHet,
@@ -29,6 +29,8 @@ const BaseVariantSearchResults = React.memo(({ inheritanceFilter, toggleUnpair, 
   if (variantId) {
     resultProps.loadVariants = loadSingleSearchedVariant
     resultProps.contentComponent = DisplayVariants
+  } else {
+    resultProps.initialLoad = initialLoad
   }
 
   if (ALL_RECESSIVE_INHERITANCE_FILTERS.includes(inheritanceFilter)) {
@@ -58,6 +60,7 @@ BaseVariantSearchResults.propTypes = {
   inheritanceFilter: PropTypes.string,
   flattenCompoundHet: PropTypes.bool,
   toggleUnpair: PropTypes.func,
+  initialLoad: PropTypes.func,
 }
 
 const mapStateToProps = (state, ownProps) => ({
@@ -72,6 +75,9 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(updateCompoundHetDisplay({
         updates,
       }))
+    },
+    initialLoad: (params) => {
+      dispatch(loadProjectFamiliesContext(params))
     },
   }
 }

--- a/ui/shared/components/DataLoader.jsx
+++ b/ui/shared/components/DataLoader.jsx
@@ -13,6 +13,7 @@ class DataLoader extends React.PureComponent
     loading: PropTypes.bool.isRequired,
     load: PropTypes.func,
     unload: PropTypes.func,
+    initialLoad: PropTypes.func,
     hideError: PropTypes.bool,
     errorMessage: PropTypes.node,
     children: PropTypes.node,
@@ -24,6 +25,9 @@ class DataLoader extends React.PureComponent
 
     if (props.load) {
       props.load(props.contentId)
+    }
+    if (props.initialLoad) {
+      props.initialLoad(props.contentId)
     }
   }
 

--- a/ui/shared/components/panel/search/VariantSearchResults.jsx
+++ b/ui/shared/components/panel/search/VariantSearchResults.jsx
@@ -131,7 +131,7 @@ const mapContentDispatchToProps = (dispatch, ownProps) => {
 const VariantSearchResultsContent = connect(mapContentStateToProps, mapContentDispatchToProps)(BaseVariantSearchResultsContent)
 
 const BaseVariantSearchResults = React.memo((
-  { match, displayVariants, load, unload, variantsLoading, contextLoading, errorMessage, contentComponent, ...props }) => {
+  { match, displayVariants, load, unload, initialLoad, variantsLoading, contextLoading, errorMessage, contentComponent, ...props }) => {
   return (
     <DataLoader
       contentId={match.params}
@@ -139,6 +139,7 @@ const BaseVariantSearchResults = React.memo((
       loading={variantsLoading || contextLoading}
       load={load}
       unload={unload}
+      initialLoad={initialLoad}
       reloadOnIdUpdate
       errorMessage={errorMessage &&
         <Grid.Row>
@@ -157,6 +158,7 @@ BaseVariantSearchResults.propTypes = {
   match: PropTypes.object,
   load: PropTypes.func,
   unload: PropTypes.func,
+  initialLoad: PropTypes.func,
   variantsLoading: PropTypes.bool,
   contextLoading: PropTypes.bool,
   errorMessage: PropTypes.string,


### PR DESCRIPTION
This fixes a bug I noticed where it does not correctly fetch some important context for searches in a few edge cases