### PR TITLE
Fix for #1444 - ui undefined filter

### DIFF
--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -415,7 +415,7 @@ export const getTagTypesByProject = createSelector(
   getProjectsByGuid,
   projectsByGuid => Object.values(projectsByGuid).reduce((acc, project) => ({
     ...acc,
-    [project.projectGuid]: project.variantTagTypes.filter(vtt => vtt.name !== NOTE_TAG_NAME),
+    [project.projectGuid]: (project.variantTagTypes || []).filter(vtt => vtt.name !== NOTE_TAG_NAME),
   }), {}),
 )
 

--- a/ui/redux/selectors.test.js
+++ b/ui/redux/selectors.test.js
@@ -7,6 +7,7 @@ import {
   getPairedFilteredSavedVariants,
   getVariantTagNotesByFamilyVariants,
   getSearchGeneBreakdownValues,
+  getTagTypesByProject,
 } from './selectors'
 import {FAMILY_GUID, GENE_ID, SEARCH, SEARCH_HASH, STATE} from "../pages/Search/fixtures";
 
@@ -102,4 +103,10 @@ test('getSearchGeneBreakdownValues', () => {
     geneId: GENE_ID,
     geneSymbol: 'OR2M3',
   }])
+})
+
+test('getTagTypesByProject', () => {
+  expect(getTagTypesByProject(STATE, {})).toEqual(
+    { R0237_1000_genomes_demo: [] },
+  )
 })


### PR DESCRIPTION
Fix for #1444 - Variant Search throws UI error - "TypeError: Cannot read property 'filter' of undefined

Build passed: https://travis-ci.com/github/ssadedin/seqr/builds/183471189
