### PR TITLE
Fix local bams

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -35,7 +35,8 @@ def file_iter(file_path, byte_range=None, raw_content=False):
         for line in _google_bucket_file_iter(file_path, byte_range=byte_range, raw_content=raw_content):
             yield line
     else:
-        with open(file_path) as f:
+        mode = 'rb' if raw_content else 'r'
+        with open(file_path, mode) as f:
             if byte_range:
                 f.seek(byte_range[0])
                 for line in f:

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -22,9 +22,11 @@ class DatasetAPITest(AuthenticationTestCase):
 
     @mock.patch('seqr.utils.redis_utils.redis.StrictRedis', mock.MagicMock())
     @mock.patch('seqr.views.utils.dataset_utils.random.randint')
-    @mock.patch('seqr.views.utils.dataset_utils.file_iter')
+    @mock.patch('seqr.utils.file_utils.open')
     @urllib3_responses.activate
-    def test_add_variants_dataset(self, mock_file_iter, mock_random):
+    def test_add_variants_dataset(self, mock_open, mock_random):
+        mock_file_iter = mock_open.return_value.__enter__.return_value.__iter__
+
         url = reverse(add_variants_dataset_handler, args=[PROJECT_GUID])
         self.check_manager_login(url)
 
@@ -167,6 +169,7 @@ class DatasetAPITest(AuthenticationTestCase):
             'datasetType': 'VARIANTS',
         }))
         self.assertEqual(response.status_code, 200)
+        mock_open.assert_called_with('mapping.csv', 'r')
 
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'samplesByGuid', 'individualsByGuid', 'familiesByGuid'})

--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -42,6 +42,7 @@ class IgvAPITest(AuthenticationTestCase):
         response = self.client.get(url, HTTP_RANGE='bytes=100-200')
         self.assertEqual(response.status_code, 206)
         self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT[:2])
+        mock_open.assert_called_with('/project_A/sample_1.bai', 'rb')
         mock_file.seek.assert_called_with(100)
 
         # test no byte range
@@ -49,5 +50,6 @@ class IgvAPITest(AuthenticationTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT)
+        mock_open.assert_called_with('/project_A/sample_1.bai', 'rb')
         mock_file.seek.assert_not_called()
 


### PR DESCRIPTION
bams and crams are binary data files and need to be opened as such for local files. Fixes the latest issue in this ticket: https://github.com/macarthur-lab/seqr/issues/1383#issuecomment-698366041